### PR TITLE
Fix 0,0 point omission in XML output

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -816,21 +816,22 @@ func (e *Event) ToXML() ([]byte, error) {
 	}
 	buf.WriteString(">\n")
 
-	// Write point if present
-	if e.Point.Lat != 0 || e.Point.Lon != 0 {
-		buf.WriteString("  <point")
-		fmt.Fprintf(&buf, ` lat="%.6f" lon="%.6f"`, e.Point.Lat, e.Point.Lon)
-		if e.Point.Hae != 0 {
-			fmt.Fprintf(&buf, ` hae="%.1f"`, e.Point.Hae)
-		}
-		if e.Point.Ce != 0 {
-			fmt.Fprintf(&buf, ` ce="%.1f"`, e.Point.Ce)
-		}
-		if e.Point.Le != 0 {
-			fmt.Fprintf(&buf, ` le="%.1f"`, e.Point.Le)
-		}
-		buf.WriteString("/>\n")
+	// Always write the point element. Previously the element was omitted
+	// when both latitude and longitude were zero, which made it
+	// impossible to encode valid locations at 0°N 0°E.  Including the
+	// element unconditionally ensures the coordinates are preserved.
+	buf.WriteString("  <point")
+	fmt.Fprintf(&buf, ` lat="%.6f" lon="%.6f"`, e.Point.Lat, e.Point.Lon)
+	if e.Point.Hae != 0 {
+		fmt.Fprintf(&buf, ` hae="%.1f"`, e.Point.Hae)
 	}
+	if e.Point.Ce != 0 {
+		fmt.Fprintf(&buf, ` ce="%.1f"`, e.Point.Ce)
+	}
+	if e.Point.Le != 0 {
+		fmt.Fprintf(&buf, ` le="%.1f"`, e.Point.Le)
+	}
+	buf.WriteString("/>\n")
 
 	// Write detail if present
 	if e.Detail != nil {

--- a/cotlib_test.go
+++ b/cotlib_test.go
@@ -767,3 +767,27 @@ func TestTypeCatalogFunctions(t *testing.T) {
 		}
 	})
 }
+func TestToXMLIncludesPointWithZeroCoordinates(t *testing.T) {
+	now := time.Now().UTC()
+	evt := &Event{
+		Version: "2.0",
+		Uid:     "zero",
+		Type:    "a-f-G",
+		Time:    CoTTime(now),
+		Start:   CoTTime(now),
+		Stale:   CoTTime(now.Add(10 * time.Second)),
+		Point: Point{
+			Lat: 0,
+			Lon: 0,
+			Ce:  9999999.0,
+			Le:  9999999.0,
+		},
+	}
+	xmlData, err := evt.ToXML()
+	if err != nil {
+		t.Fatalf("ToXML returned error: %v", err)
+	}
+	if !strings.Contains(string(xmlData), "<point") {
+		t.Error("point element missing in XML output")
+	}
+}


### PR DESCRIPTION
## Summary
- always write the point element in `Event.ToXML`
- test that zero coordinates are serialized correctly

## Testing
- `go test ./...`
