### PR TITLE
fix DOCTYPE detection and add tests

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -79,6 +79,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -458,6 +459,9 @@ var (
 	ErrInvalidUID      = fmt.Errorf("invalid UID")
 )
 
+// doctypePattern matches XML DOCTYPE declarations case-insensitively
+var doctypePattern = regexp.MustCompile(`(?i)<!\s*DOCTYPE`)
+
 // Contact represents contact information
 type Contact struct {
 	Callsign string `xml:"callsign,attr,omitempty"`
@@ -736,8 +740,8 @@ func FindTypesByFullName(name string) []cottypes.Type {
 
 // UnmarshalXMLEvent parses an XML byte slice into an Event
 func UnmarshalXMLEvent(data []byte) (*Event, error) {
-	// Check for DOCTYPE
-	if bytes.Contains(data, []byte("<!DOCTYPE")) {
+	// Check for DOCTYPE in a case-insensitive manner
+	if doctypePattern.Match(data) {
 		return nil, ErrInvalidInput
 	}
 

--- a/test/validation/validation_test.go
+++ b/test/validation/validation_test.go
@@ -85,6 +85,21 @@ func TestValidationBaseline(t *testing.T) {
 		}
 	})
 
+	t.Run("doctype_variations", func(t *testing.T) {
+		// Test DOCTYPE rejection with case and spacing variations
+		cases := []string{
+			`<?xml version="1.0"?><!doctype foo><event></event>`,
+			`<?xml version="1.0"?><!DoCtYpE foo><event></event>`,
+			`<?xml version="1.0"?><!   DOCTYPE foo><event></event>`,
+		}
+		for _, xmlStr := range cases {
+			_, err := cotlib.UnmarshalXMLEvent([]byte(xmlStr))
+			if !errors.Is(err, cotlib.ErrInvalidInput) {
+				t.Errorf("Expected DOCTYPE to be rejected for %q", xmlStr)
+			}
+		}
+	})
+
 	t.Run("logger_context", func(t *testing.T) {
 		// Test logger context propagation
 		ctx := context.Background()


### PR DESCRIPTION
## Summary
- improve DOCTYPE detection when unmarshalling XML events
- add tests to ensure DOCTYPE variations are rejected

## Testing
- `go test ./...`
