### PR TITLE
Add benchmarks for heavy operations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,11 @@ This project adheres to a standard code of conduct. By participating, you are ex
    go test -v ./...
    ```
 
+4. **Running Benchmarks**
+   ```bash
+   go test -bench .
+   ```
+
 ### Logging
 
 - Use `slog` for all logging

--- a/cotlib_bench_test.go
+++ b/cotlib_bench_test.go
@@ -1,0 +1,36 @@
+package cotlib
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkToXML(b *testing.B) {
+	evt, err := NewEvent("bench", "a-f-G", 30.0, -85.0, 0.0)
+	if err != nil {
+		b.Fatalf("NewEvent returned error: %v", err)
+	}
+	for i := 0; i < b.N; i++ {
+		if _, err := evt.ToXML(); err != nil {
+			b.Fatalf("ToXML error: %v", err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalXMLEvent(b *testing.B) {
+	evt, err := NewEvent("bench", "a-f-G", 30.0, -85.0, 0.0)
+	if err != nil {
+		b.Fatalf("NewEvent returned error: %v", err)
+	}
+	xmlData, err := evt.ToXML()
+	if err != nil {
+		b.Fatalf("ToXML error: %v", err)
+	}
+	xmlData = bytes.Replace(xmlData, []byte("<event"), []byte("<event version=\"2.0\""), 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := UnmarshalXMLEvent(xmlData); err != nil {
+			b.Fatalf("UnmarshalXMLEvent error: %v", err)
+		}
+	}
+}

--- a/cottypes/catalog_bench_test.go
+++ b/cottypes/catalog_bench_test.go
@@ -1,0 +1,22 @@
+package cottypes
+
+import "testing"
+
+func BenchmarkCatalogGetType(b *testing.B) {
+	cat := GetCatalog()
+	for i := 0; i < b.N; i++ {
+		if _, err := cat.GetType("a-f-G-E-X-N"); err != nil {
+			b.Fatalf("GetType error: %v", err)
+		}
+	}
+}
+
+func BenchmarkCatalogFindByFullName(b *testing.B) {
+	cat := GetCatalog()
+	for i := 0; i < b.N; i++ {
+		res := cat.FindByFullName("Nbc Equipment")
+		if len(res) == 0 {
+			b.Fatal("no results")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add benchmark tests for ToXML and UnmarshalXMLEvent
- add benchmarks for catalog lookups
- document running benchmarks in CONTRIBUTING

## Testing
- `go test ./...`
- `go test -bench . ./...`
