### PR TITLE
Support version attribute in ToXML

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -803,6 +803,9 @@ func (e *Event) ToXML() ([]byte, error) {
 
 	// Start event element
 	buf.WriteString("<event")
+	if e.Version != "" {
+		fmt.Fprintf(&buf, ` version="%s"`, e.Version)
+	}
 	if e.Type != "" {
 		fmt.Fprintf(&buf, ` type="%s"`, e.Type)
 	}

--- a/cotlib_bench_test.go
+++ b/cotlib_bench_test.go
@@ -1,7 +1,6 @@
 package cotlib
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -26,7 +25,6 @@ func BenchmarkUnmarshalXMLEvent(b *testing.B) {
 	if err != nil {
 		b.Fatalf("ToXML error: %v", err)
 	}
-	xmlData = bytes.Replace(xmlData, []byte("<event"), []byte("<event version=\"2.0\""), 1)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if _, err := UnmarshalXMLEvent(xmlData); err != nil {

--- a/cotlib_test.go
+++ b/cotlib_test.go
@@ -787,6 +787,9 @@ func TestToXMLIncludesPointWithZeroCoordinates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ToXML returned error: %v", err)
 	}
+	if !strings.Contains(string(xmlData), `version="2.0"`) {
+		t.Error("version attribute missing in XML output")
+	}
 	if !strings.Contains(string(xmlData), "<point") {
 		t.Error("point element missing in XML output")
 	}


### PR DESCRIPTION
## Summary
- add version attribute when serializing Event
- check for version in XML test
- simplify XML unmarshalling benchmark

## Testing
- `go test ./...`
- `go test -bench .`
