### PR TITLE
Update catalog docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ func main() {
 }
 ```
 
+`catalog.Upsert` precomputes upper-case versions of each type's `Description` and
+`FullName`. Search helpers reuse these cached strings to avoid allocations,
+with `BenchmarkCatalogFindByFullName` around 270–300µs and ~592 B across five
+allocations per call.
+
 ### Type Validation
 
 The library enforces strict validation of CoT types:


### PR DESCRIPTION
## Summary
- document caching behavior in catalog.Upsert

## Testing
- `go test ./...`
- `go test ./cottypes -bench=CatalogFindByFullName -benchmem | tail -n 3`