### PR TITLE
Reuse xml decoders with pooling

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -140,9 +140,9 @@ func checkXMLLimits(data []byte) error {
 		return ErrInvalidInput
 	}
 
-	dec := xml.NewDecoder(bytes.NewReader(data))
-	dec.CharsetReader = nil
-	dec.Entity = nil
+	pd := getDecoder(data)
+	defer putDecoder(pd)
+	dec := pd.dec
 
 	depth := 0
 	count := 0
@@ -828,9 +828,9 @@ func UnmarshalXMLEvent(data []byte) (*Event, error) {
 	}
 
 	// Create a secure decoder with limits
-	decoder := xml.NewDecoder(io.LimitReader(bytes.NewReader(data), int64(len(data))))
-	decoder.CharsetReader = nil // Disable charset conversion
-	decoder.Entity = nil        // Disable entity expansion
+	pd := getDecoder(data)
+	defer putDecoder(pd)
+	decoder := pd.dec
 
 	var evt Event
 	if err := decoder.Decode(&evt); err != nil {

--- a/decoder_pool.go
+++ b/decoder_pool.go
@@ -1,0 +1,34 @@
+package cotlib
+
+import (
+	"bytes"
+	"encoding/xml"
+	"sync"
+)
+
+// pooledDecoder wraps an xml.Decoder with a reusable bytes.Reader.
+type pooledDecoder struct {
+	dec *xml.Decoder
+	br  *bytes.Reader
+}
+
+var decoderPool = sync.Pool{
+	New: func() any {
+		br := bytes.NewReader(nil)
+		return &pooledDecoder{dec: xml.NewDecoder(br), br: br}
+	},
+}
+
+func getDecoder(data []byte) *pooledDecoder {
+	pd := decoderPool.Get().(*pooledDecoder)
+	pd.br.Reset(data)
+	pd.dec = xml.NewDecoder(pd.br)
+	pd.dec.CharsetReader = nil
+	pd.dec.Entity = nil
+	return pd
+}
+
+func putDecoder(pd *pooledDecoder) {
+	pd.br.Reset(nil)
+	decoderPool.Put(pd)
+}


### PR DESCRIPTION
## Summary
- add decoder_pool.go to manage sync.Pool of xml.Decoder objects with reusable bytes.Reader
- apply pooled decoder in checkXMLLimits and UnmarshalXMLEvent

## Testing
- `go test ./...`
- `go test ./... -bench BenchmarkUnmarshalXMLEvent -benchmem`