### PR TITLE
Add XML decode limit enforcement

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -148,11 +148,15 @@ func checkXMLLimits(data []byte) error {
 	count := 0
 
 	for {
-		tok, err := dec.Token()
+		off := dec.InputOffset()
+		tok, err := dec.RawToken()
 		if err != nil {
 			if err == io.EOF {
 				break
 			}
+			return ErrInvalidInput
+		}
+		if dec.InputOffset()-off > maxTokenLen {
 			return ErrInvalidInput
 		}
 		count++
@@ -809,6 +813,9 @@ func FindTypesByFullName(name string) []cottypes.Type {
 
 // UnmarshalXMLEvent parses an XML byte slice into an Event
 func UnmarshalXMLEvent(data []byte) (*Event, error) {
+	if len(data) > maxXMLSize {
+		return nil, ErrInvalidInput
+	}
 	// Check for DOCTYPE in a case-insensitive manner
 	if doctypePattern.Match(data) {
 		return nil, ErrInvalidInput

--- a/test/validation/validation_test.go
+++ b/test/validation/validation_test.go
@@ -207,6 +207,37 @@ func TestValidationBaseline(t *testing.T) {
 			t.Error("Expected namespace length error")
 		}
 	})
+
+	t.Run("max_xml_size", func(t *testing.T) {
+		big := strings.Repeat("a", (2<<20)+1)
+		xmlData := []byte("<event>" + big + "</event>")
+		_, err := cotlib.UnmarshalXMLEvent(xmlData)
+		if !errors.Is(err, cotlib.ErrInvalidInput) {
+			t.Error("Expected size limit error")
+		}
+	})
+
+	t.Run("token_length_limit", func(t *testing.T) {
+		name := strings.Repeat("x", 1025)
+		xmlData := []byte("<event><" + name + "/></event>")
+		_, err := cotlib.UnmarshalXMLEvent(xmlData)
+		if !errors.Is(err, cotlib.ErrInvalidInput) {
+			t.Error("Expected token length error")
+		}
+	})
+
+	t.Run("element_count_limit", func(t *testing.T) {
+		var b strings.Builder
+		b.WriteString("<event>")
+		for i := 0; i < 10001; i++ {
+			b.WriteString("<a></a>")
+		}
+		b.WriteString("</event>")
+		_, err := cotlib.UnmarshalXMLEvent([]byte(b.String()))
+		if !errors.Is(err, cotlib.ErrInvalidInput) {
+			t.Error("Expected element count error")
+		}
+	})
 }
 
 func TestWildcardPatterns(t *testing.T) {


### PR DESCRIPTION
## Summary
- enforce XML input size before decoding
- tighten token processing limits
- test decoder limit conditions

## Testing
- `go test ./...`