### PR TITLE
Add XML limit setters and round-trip test

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,12 +274,17 @@ The library implements several security measures:
 - Coordinate range enforcement
 - Time field validation to prevent time-based attacks
 - Maximum value length controls
+- Configurable parser limits
 - Secure logging practices
 
 ```go
 // Set maximum allowed length for XML attribute values
 // This protects against memory exhaustion attacks
 cotlib.SetMaxValueLen(500 * 1024) // 500KB limit
+cotlib.SetMaxXMLSize(2 << 20)    // 2MB overall XML size
+cotlib.SetMaxElementDepth(32)    // nesting depth limit
+cotlib.SetMaxElementCount(10000) // total element limit
+cotlib.SetMaxTokenLen(1024)      // single token size
 ```
 
 ### Logging
@@ -296,6 +301,16 @@ logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 }))
 
 ctx := cotlib.WithLogger(context.Background(), logger)
+```
+
+### Event Pooling
+
+`UnmarshalXMLEvent` reuses `Event` objects from an internal pool to reduce
+allocations. When you are done with an event, return it to the pool:
+
+```go
+evt, _ := cotlib.UnmarshalXMLEvent(data)
+defer cotlib.ReleaseEvent(evt)
 ```
 
 ## Benchmarks

--- a/init.go
+++ b/init.go
@@ -14,6 +14,13 @@ func init() {
 	if l := logger.Load(); l == nil {
 		logger.Store(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	}
+
+	// Set default XML parsing limits
+	SetMaxXMLSize(2 << 20)
+	SetMaxElementDepth(32)
+	SetMaxElementCount(10000)
+	SetMaxTokenLen(1024)
+	SetMaxValueLen(512 * 1024)
 }
 
 // SetLogger sets the package-level logger

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -1,0 +1,24 @@
+package cotlib
+
+import "testing"
+
+func TestUnmarshalXMLEventRoundTrip(t *testing.T) {
+	orig, err := NewEvent("RT1", "a-f-G", 10.0, 20.0, 0)
+	if err != nil {
+		t.Fatalf("new event: %v", err)
+	}
+	xmlData, err := orig.ToXML()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	ReleaseEvent(orig)
+
+	evt, err := UnmarshalXMLEvent(xmlData)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if evt.Uid != "RT1" || evt.Type != "a-f-G" {
+		t.Errorf("unexpected event: %#v", evt)
+	}
+	ReleaseEvent(evt)
+}


### PR DESCRIPTION
## Summary
- make XML parsing limits configurable via setters
- document XML limit configuration and event pooling
- describe UnmarshalXMLEvent behavior
- add a round-trip test using UnmarshalXMLEvent

## Testing
- `go test ./...`