### PR TITLE
Add benchmarks for ValidateType and description search

### DIFF
--- a/cotlib_bench_test.go
+++ b/cotlib_bench_test.go
@@ -66,6 +66,39 @@ func BenchmarkUnmarshalXMLEventNoPool(b *testing.B) {
 	}
 }
 
+func BenchmarkValidateType(b *testing.B) {
+	types := []string{
+		"a-f-G",       // Valid basic type
+		"a-f-G-E-X-N", // Valid catalog type
+		"a-f-G-*",     // Valid wildcard
+		"a-.-X",       // Valid atomic wildcard
+		"invalid",     // Invalid
+		"a-f-INVALID", // Invalid format
+		"a-f-G-Z-Z-Z", // Unknown but valid format
+	}
+	b.ReportAllocs()
+	for _, typ := range types {
+		b.Run(typ, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = ValidateType(typ)
+			}
+		})
+	}
+}
+
+func BenchmarkDecodeWithLimits(b *testing.B) {
+	xmlStr := `<event version="2.0" uid="bench" type="a-f-G"><point lat="1" lon="2" hae="3"/></event>`
+	data := []byte(xmlStr)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		dec := xml.NewDecoder(bytes.NewReader(data))
+		evt := Event{}
+		if err := decodeWithLimits(dec, &evt); err != nil {
+			b.Fatalf("decodeWithLimits error: %v", err)
+		}
+	}
+}
+
 func unmarshalXMLEventNoPool(data []byte) (*Event, error) {
 	if doctypePattern.Match(data) {
 		return nil, ErrInvalidInput

--- a/cotlib_test.go
+++ b/cotlib_test.go
@@ -442,39 +442,6 @@ func TestValidateType(t *testing.T) {
 	}
 }
 
-// TestValidateTypePerformance tests the performance of the ValidateType function
-func TestValidateTypePerformance(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping performance test in short mode")
-	}
-
-	// Test a mix of valid catalog types, wildcards, and invalid types
-	types := []string{
-		"a-f-G",       // Valid basic type
-		"a-f-G-E-X-N", // Valid catalog type
-		"a-f-G-*",     // Valid wildcard
-		"a-.-X",       // Valid atomic wildcard
-		"invalid",     // Invalid
-		"a-f-INVALID", // Invalid format
-		"a-f-G-Z-Z-Z", // Unknown but valid format
-	}
-
-	// Number of iterations for each type
-	iterations := 1000
-
-	for _, typ := range types {
-		t.Run("perf_"+typ, func(t *testing.T) {
-			start := time.Now()
-			for i := 0; i < iterations; i++ {
-				_ = ValidateType(typ)
-			}
-			elapsed := time.Since(start)
-			nsPerOp := float64(elapsed.Nanoseconds()) / float64(iterations)
-			t.Logf("ValidateType(%q): %v ns/op", typ, nsPerOp)
-		})
-	}
-}
-
 func TestWildcardExpansion(t *testing.T) {
 	// Test that expanded types are valid
 	expandedTypes := []string{

--- a/cottypes/catalog_bench_test.go
+++ b/cottypes/catalog_bench_test.go
@@ -20,3 +20,13 @@ func BenchmarkCatalogFindByFullName(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkCatalogFindByDescription(b *testing.B) {
+	cat := GetCatalog()
+	for i := 0; i < b.N; i++ {
+		res := cat.FindByDescription("NBC EQUIPMENT")
+		if len(res) == 0 {
+			b.Fatal("no results")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- convert ValidateType performance test to formal benchmarks
- cover secure XML decoder and catalog description searches
- remove old ValidateType performance test

## Testing
- `go test -v ./...`
- `go test -bench . ./...`
