### PR TITLE
Allow sentinel HAE value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 
 ### Changed
--
+- Allowed `HAE` sentinel value `9999999.0` and expanded valid range to -12000..40000000
 
 ### Deprecated
 -

--- a/cotlib.go
+++ b/cotlib.go
@@ -483,8 +483,10 @@ func (p *Point) Validate() error {
 	}
 
 	// Validate height above ellipsoid (HAE)
-	// HAE must be between -10000 (Dead Sea) and 100000 (edge of space)
-	if p.Hae < -10000 || p.Hae > 100000 {
+	// Lower bound: Mariana Trench depth (-12000m) with safety margin
+	// Upper bound: Geostationary orbit (40000km) for space assets
+	// Special case: 9999999.0 is allowed as traditional TAK "unknown altitude"
+	if p.Hae < -12000 || (p.Hae > 40000000 && p.Hae != 9999999.0) {
 		return fmt.Errorf("invalid HAE: %f", p.Hae)
 	}
 

--- a/cotlib_test.go
+++ b/cotlib_test.go
@@ -585,6 +585,28 @@ func TestPointValidation(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "sentinel HAE allowed",
+			point: &Point{
+				Lat: 37.7749,
+				Lon: -122.4194,
+				Hae: 9999999.0,
+				Ce:  9999999.0,
+				Le:  9999999.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "HAE above limit",
+			point: &Point{
+				Lat: 37.7749,
+				Lon: -122.4194,
+				Hae: 40000001.0,
+				Ce:  9999999.0,
+				Le:  9999999.0,
+			},
+			wantErr: true,
+		},
+		{
 			name: "invalid latitude",
 			point: &Point{
 				Lat: 91.0,


### PR DESCRIPTION
## Summary
- allow HAE sentinel 9999999.0 and broaden validation range
- add tests covering new HAE rules
- note range change in changelog

## Testing
- `go test -v ./...`