### PR TITLE
Add CoT type explainer package

### DIFF
--- a/cotexplainer/cotexplainer_test.go
+++ b/cotexplainer/cotexplainer_test.go
@@ -1,0 +1,45 @@
+package cotexplainer_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/NERVsystems/cotlib/cotexplainer"
+)
+
+func TestExplainType(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		got, err := cotexplainer.ExplainType("a-f-G-E-X-N")
+		if err != nil {
+			t.Fatalf("ExplainType() error = %v", err)
+		}
+		want := []string{"Atom", "Friendly", "Ground", "EQUIPMENT", "SPECIAL EQUIPMENT", "NBC EQUIPMENT"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("ExplainType() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("unknown_atom", func(t *testing.T) {
+		if _, err := cotexplainer.ExplainType("z-f-G"); err == nil {
+			t.Error("expected error for unknown atom")
+		}
+	})
+
+	t.Run("unknown_affiliation", func(t *testing.T) {
+		if _, err := cotexplainer.ExplainType("a-x-G"); err == nil {
+			t.Error("expected error for unknown affiliation")
+		}
+	})
+
+	t.Run("unknown_dimension", func(t *testing.T) {
+		if _, err := cotexplainer.ExplainType("a-f-Z"); err == nil {
+			t.Error("expected error for unknown battle dimension")
+		}
+	})
+
+	t.Run("unknown_segment", func(t *testing.T) {
+		if _, err := cotexplainer.ExplainType("a-f-G-unknown"); err == nil {
+			t.Error("expected error for unknown segment")
+		}
+	})
+}

--- a/cotexplainer/explainer.go
+++ b/cotexplainer/explainer.go
@@ -1,0 +1,81 @@
+package cotexplainer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NERVsystems/cotlib/cottypes"
+)
+
+var atomMap = map[string]string{
+	"a": "Atom",
+	"b": "Bits",
+	"c": "Capability",
+	"t": "Tasking",
+	"y": "Reply",
+}
+
+var affiliationMap = map[string]string{
+	"f": "Friendly",
+	"h": "Hostile",
+	"n": "Neutral",
+	"u": "Unknown",
+	"p": "Pending",
+	"a": "Assumed Friend",
+	"s": "Suspect",
+}
+
+var battleDimensionMap = map[string]string{
+	"A": "Air",
+	"G": "Ground",
+	"S": "Surface",
+	"U": "Subsurface",
+	"X": "Other",
+	"P": "Space",
+}
+
+// ExplainType resolves a CoT type code into its component meanings.
+//
+// It returns a slice of descriptions for each level of the type hierarchy.
+func ExplainType(code string) ([]string, error) {
+	if code == "" {
+		return nil, fmt.Errorf("empty type")
+	}
+
+	parts := strings.Split(code, "-")
+	if len(parts) < 3 { // need at least atom, affiliation and dimension
+		return nil, fmt.Errorf("invalid type format")
+	}
+
+	res := make([]string, 0, len(parts))
+
+	atom, ok := atomMap[parts[0]]
+	if !ok {
+		return nil, fmt.Errorf("unknown atom prefix: %s", parts[0])
+	}
+	res = append(res, atom)
+
+	aff, ok := affiliationMap[parts[1]]
+	if !ok {
+		return nil, fmt.Errorf("unknown affiliation: %s", parts[1])
+	}
+	res = append(res, aff)
+
+	dim, ok := battleDimensionMap[parts[2]]
+	if !ok {
+		return nil, fmt.Errorf("unknown battle dimension: %s", parts[2])
+	}
+	res = append(res, dim)
+
+	prefix := strings.Join(parts[:3], "-")
+	for _, seg := range parts[3:] {
+		prefix += "-" + seg
+		typ, err := cottypes.GetCatalog().GetType(prefix)
+		if err != nil {
+			return nil, fmt.Errorf("unknown type segment: %s", seg)
+		}
+		res = append(res, typ.Description)
+	}
+
+	return res, nil
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/NERVsystems/cotlib"
+	"github.com/NERVsystems/cotlib/cotexplainer"
 )
 
 func ExampleNewEvent() {
@@ -217,4 +218,22 @@ func ExampleFindTypesByFullName() {
 	// Found type: a-h-G-E-X-N (Gnd/Equip/Nbc Equipment)
 	// Found type: a-n-G-E-X-N (Gnd/Equip/Nbc Equipment)
 	// Found type: a-u-G-E-X-N (Gnd/Equip/Nbc Equipment)
+}
+
+func ExampleExplainType() {
+	parts, err := cotexplainer.ExplainType("a-f-G-E-X-N")
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	for _, p := range parts {
+		fmt.Println(p)
+	}
+	// Output:
+	// Atom
+	// Friendly
+	// Ground
+	// EQUIPMENT
+	// SPECIAL EQUIPMENT
+	// NBC EQUIPMENT
 }


### PR DESCRIPTION
## Summary
- add `cotexplainer` package with `ExplainType` to decode CoT type strings
- cover edge cases with new tests
- document usage with an example

## Testing
- `go test ./...`