### PR TITLE
Enforce UID length and whitespace constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ The library implements several security measures:
 - Time field validation to prevent time-based attacks
 - Maximum value length controls
 - Configurable parser limits
+- UID values are limited to 64 characters and may not contain whitespace
 - Secure logging practices
 
 ```go

--- a/cotlib.go
+++ b/cotlib.go
@@ -909,7 +909,9 @@ func ValidateLatLon(lat, lon float64) error {
 	return nil
 }
 
-// ValidateUID checks if a UID is valid
+// ValidateUID checks if a UID is valid.
+// It rejects empty values, leading hyphens, double dots,
+// whitespace, and UIDs longer than 64 characters.
 func ValidateUID(uid string) error {
 	if uid == "" {
 		return ErrInvalidUID
@@ -918,6 +920,12 @@ func ValidateUID(uid string) error {
 		return ErrInvalidUID
 	}
 	if strings.Contains(uid, "..") {
+		return ErrInvalidUID
+	}
+	if len(uid) > 64 {
+		return ErrInvalidUID
+	}
+	if strings.ContainsAny(uid, " \t\n\r") {
 		return ErrInvalidUID
 	}
 	return nil

--- a/test/validation/validation_test.go
+++ b/test/validation/validation_test.go
@@ -149,11 +149,13 @@ func TestValidationBaseline(t *testing.T) {
 			uid     string
 			wantErr bool
 		}{
-			{"7", false},   // Single char
-			{"A_", false},  // Trailing underscore
-			{"-a", true},   // Leading hyphen
-			{"a..b", true}, // Double dot
-			{"abc", false}, // Normal case
+			{"7", false},                    // Single char
+			{"A_", false},                   // Trailing underscore
+			{"-a", true},                    // Leading hyphen
+			{"a..b", true},                  // Double dot
+			{"abc", false},                  // Normal case
+			{strings.Repeat("x", 65), true}, // Too long
+			{"has space", true},             // Contains whitespace
 		}
 		for _, tc := range cases {
 			err := cotlib.ValidateUID(tc.uid)


### PR DESCRIPTION
## Summary
- tighten UID validation logic
- test long and whitespace-containing UIDs
- document UID restrictions in README

## Testing
- `go test -v ./...`
