### PR TITLE
Fix event leak on XML parse error

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -888,10 +888,12 @@ func UnmarshalXMLEvent(data []byte) (*Event, error) {
 
 	evt := getEvent()
 	if err := decodeWithLimits(pd.dec, evt); err != nil {
+		ReleaseEvent(evt)
 		return nil, fmt.Errorf("failed to decode XML: %w", err)
 	}
 
 	if err := evt.ValidateAt(time.Now().UTC()); err != nil {
+		ReleaseEvent(evt)
 		return nil, err
 	}
 

--- a/event_pool_test.go
+++ b/event_pool_test.go
@@ -1,0 +1,29 @@
+package cotlib
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestEventPoolReuseOnInvalidXML(t *testing.T) {
+	// Disable GC to prevent sync.Pool cleanup
+	pct := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(pct)
+
+	// Prime pool with a single event
+	base := getEvent()
+	ReleaseEvent(base)
+
+	// Parse invalid XML to trigger error after pool allocation
+	invalid := []byte("<event><bad></event>")
+	if _, err := UnmarshalXMLEvent(invalid); err == nil {
+		t.Fatal("expected error from invalid XML")
+	}
+
+	// Get event from pool; should be the same object
+	e := getEvent()
+	if e != base {
+		t.Error("event was not returned to pool after failure")
+	}
+	ReleaseEvent(e)
+}


### PR DESCRIPTION
## Summary
- release pooled Event when XML decoding or validation fails
- add regression test ensuring pool reuse on invalid XML

## Testing
- `go test -v ./...`