### PR TITLE
feat(ctx): add context-aware logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,10 @@ if err := cotlib.ValidateType("a-f-G-E-V-custom"); err != nil {
     log.Fatal(err)
 }
 
+ctx := cotlib.WithLogger(context.Background(), logger)
+
 // Register types from a file
-if err := cotlib.RegisterCoTTypesFromFile("my-types.xml"); err != nil {
+if err := cotlib.RegisterCoTTypesFromFile(ctx, "my-types.xml"); err != nil {
     log.Fatal(err)
 }
 
@@ -320,7 +322,7 @@ xmlContent := `<types>
     <cot cot="a-f-G-custom"/>
     <cot cot="a-h-A-custom"/>
 </types>`
-if err := cotlib.RegisterCoTTypesFromXMLContent(xmlContent); err != nil {
+if err := cotlib.RegisterCoTTypesFromXMLContent(ctx, xmlContent); err != nil {
     log.Fatal(err)
 }
 ```
@@ -467,6 +469,8 @@ logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 }))
 
 ctx := cotlib.WithLogger(context.Background(), logger)
+log := cotlib.LoggerFromContext(ctx)
+log.Info("logger ready")
 ```
 
 ### Event Pooling

--- a/cmd/logcheck/main.go
+++ b/cmd/logcheck/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -23,6 +24,8 @@ func main() {
 	cotlib.SetLogger(logger)
 	cottypes.SetLogger(logger)
 
+	ctx := cotlib.WithLogger(context.Background(), logger)
+
 	fmt.Println("Step 1: Using cottypes.RegisterXML directly")
 	// Test loading with cottypes.RegisterXML
 	data, err := os.ReadFile("cottypes/CoTtypes.xml")
@@ -31,7 +34,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = cottypes.RegisterXML(data)
+	err = cottypes.RegisterXML(ctx, data)
 	if err != nil {
 		fmt.Printf("Error registering XML: %v\n", err)
 		os.Exit(1)
@@ -45,7 +48,7 @@ func main() {
 
 	fmt.Println("\nStep 2: Using cotlib.RegisterCoTTypesFromFile")
 	// Test loading with cotlib.RegisterCoTTypesFromFile
-	err = cotlib.RegisterCoTTypesFromFile("cottypes/CoTtypes.xml")
+	err = cotlib.RegisterCoTTypesFromFile(ctx, "cottypes/CoTtypes.xml")
 	if err != nil {
 		fmt.Printf("Error registering types from file: %v\n", err)
 		os.Exit(1)
@@ -59,7 +62,7 @@ func main() {
 
 	fmt.Println("\nStep 3: Using cotlib.LoadCoTTypesFromFile")
 	// Test loading with cotlib.LoadCoTTypesFromFile
-	err = cotlib.LoadCoTTypesFromFile("cottypes/CoTtypes.xml")
+	err = cotlib.LoadCoTTypesFromFile(ctx, "cottypes/CoTtypes.xml")
 	if err != nil {
 		fmt.Printf("Error loading types from file: %v\n", err)
 		os.Exit(1)

--- a/cotlib.go
+++ b/cotlib.go
@@ -76,6 +76,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"github.com/NERVsystems/cotlib/ctxlog"
 	"io"
 	"log/slog"
 	"os"
@@ -242,8 +243,8 @@ func basicSyntaxOK(name string) bool {
 }
 
 // RegisterCoTTypesFromFile loads and registers CoT types from an XML file
-func RegisterCoTTypesFromFile(filename string) error {
-	logger := slog.Default()
+func RegisterCoTTypesFromFile(ctx context.Context, filename string) error {
+	logger := LoggerFromContext(ctx)
 
 	file, err := os.Open(filename)
 	if err != nil {
@@ -288,8 +289,8 @@ func RegisterCoTTypesFromFile(filename string) error {
 }
 
 // RegisterCoTTypesFromReader loads and registers CoT types from an XML reader
-func RegisterCoTTypesFromReader(r io.Reader) error {
-	logger := slog.Default()
+func RegisterCoTTypesFromReader(ctx context.Context, r io.Reader) error {
+	logger := LoggerFromContext(ctx)
 	decoder := xml.NewDecoder(r)
 
 	// Simple structure to parse the XML
@@ -324,8 +325,8 @@ func RegisterCoTTypesFromReader(r io.Reader) error {
 
 // RegisterCoTTypesFromXMLContent registers CoT types from the given XML content string
 // This is particularly useful for embedding the CoTtypes.xml content directly in code
-func RegisterCoTTypesFromXMLContent(xmlContent string) error {
-	logger := slog.Default()
+func RegisterCoTTypesFromXMLContent(ctx context.Context, xmlContent string) error {
+	logger := LoggerFromContext(ctx)
 
 	// Use a Reader for the XML content
 	reader := strings.NewReader(xmlContent)
@@ -369,8 +370,8 @@ func RegisterAllCoTTypes() error {
 }
 
 // LoadCoTTypesFromFile loads CoT types from a file
-func LoadCoTTypesFromFile(path string) error {
-	logger := slog.Default()
+func LoadCoTTypesFromFile(ctx context.Context, path string) error {
+	logger := LoggerFromContext(ctx)
 
 	// Read the file
 	data, err := os.ReadFile(path)
@@ -806,10 +807,13 @@ func (e *Event) Is(pred string) bool {
 
 // WithLogger adds a logger to the context
 func WithLogger(ctx context.Context, l *slog.Logger) context.Context {
-	return context.WithValue(ctx, loggerKey{}, l)
+	return ctxlog.WithLogger(ctx, l)
 }
 
-type loggerKey struct{}
+// LoggerFromContext retrieves the logger from context or returns slog.Default.
+func LoggerFromContext(ctx context.Context) *slog.Logger {
+	return ctxlog.LoggerFromContext(ctx)
+}
 
 // GetTypeFullName returns the full hierarchical name for a CoT type.
 // For example, "a-f-G-E-X-N" returns "Gnd/Equip/Nbc Equipment".

--- a/cottypes/types_embed.go
+++ b/cottypes/types_embed.go
@@ -2,8 +2,10 @@ package cottypes
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"fmt"
+	"github.com/NERVsystems/cotlib/ctxlog"
 	"log/slog"
 	"strings"
 	"sync"
@@ -95,7 +97,9 @@ func GetCatalog() *Catalog {
 }
 
 // RegisterXML registers CoT types from XML content into the catalog.
-func RegisterXML(data []byte) error {
+func RegisterXML(ctx context.Context, data []byte) error {
+	logger := ctxlog.LoggerFromContext(ctx)
+
 	var types struct {
 		Types []struct {
 			Cot  string `xml:"cot,attr"`

--- a/cottypes/types_embed_test.go
+++ b/cottypes/types_embed_test.go
@@ -2,12 +2,14 @@ package cottypes_test
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/NERVsystems/cotlib/cottypes"
+	"github.com/NERVsystems/cotlib/ctxlog"
 )
 
 // TestRegisterXML tests that RegisterXML correctly logs a summary and not individual types
@@ -28,8 +30,9 @@ func TestRegisterXML(t *testing.T) {
 		t.Fatalf("Failed to read XML file: %v", err)
 	}
 
-	// Register the XML types
-	err = cottypes.RegisterXML(data)
+	// Register the XML types using a context with logger
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+	err = cottypes.RegisterXML(ctx, data)
 	if err != nil {
 		t.Fatalf("Failed to register XML types: %v", err)
 	}
@@ -77,8 +80,9 @@ func TestRealWorldTypeRegistration(t *testing.T) {
 		t.Fatalf("Failed to read XML file: %v", err)
 	}
 
-	// Register the XML types
-	err = cottypes.RegisterXML(data)
+	// Register the XML types using a context with logger
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+	err = cottypes.RegisterXML(ctx, data)
 	if err != nil {
 		t.Fatalf("Failed to register XML types: %v", err)
 	}

--- a/ctxlog/context.go
+++ b/ctxlog/context.go
@@ -1,0 +1,22 @@
+package ctxlog
+
+import (
+	"context"
+	"log/slog"
+)
+
+type loggerKey struct{}
+
+// WithLogger returns a new context with the provided logger attached.
+func WithLogger(ctx context.Context, l *slog.Logger) context.Context {
+	return context.WithValue(ctx, loggerKey{}, l)
+}
+
+// LoggerFromContext retrieves the logger stored in the context. If no logger
+// is found, slog.Default() is returned.
+func LoggerFromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(loggerKey{}).(*slog.Logger); ok && l != nil {
+		return l
+	}
+	return slog.Default()
+}


### PR DESCRIPTION
## Summary
- introduce ctxlog package for logger helpers
- use LoggerFromContext in CoT type helpers
- add context parameter to RegisterXML and library functions
- update README and examples
- adjust tests for context logging

## Testing
- `go test -v ./...`