### PR TITLE
Add extension example and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- 
+- Detail extensions with round-trip preservation in `Detail.Extensions`
 
 ### Changed
 - Allowed `HAE` sentinel value `9999999.0` and expanded valid range to -12000..40000000

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A comprehensive Go library for creating, validating, and working with Cursor-on-
 - Type validation and registration
 - Secure logging with slog
 - Thread-safe operations
+- Detail extensions with round-trip preservation
 - Predicate-based event classification
 - Security-first design
 - Wildcard pattern support for types
@@ -129,6 +130,28 @@ func main() {
         fmt.Println("This is a ground-based entity")
     }
 }
+```
+
+#### Handling Detail Extensions
+
+CoT events often include TAK-specific extensions inside the `<detail>` element.
+Unknown elements are preserved in `Detail.Extensions` and serialized back
+verbatim:
+
+```go
+xmlData := `<?xml version="1.0"?>
+<event version="2.0" uid="CHAT-1" type="t-x-c" time="2023-05-15T18:30:22Z" start="2023-05-15T18:30:22Z" stale="2023-05-15T18:30:32Z">
+  <point lat="0" lon="0" ce="9999999.0" le="9999999.0"/>
+  <detail>
+    <__chat message="Hello world!" sender="Alpha"/>
+  </detail>
+</event>`
+
+evt, _ := cotlib.UnmarshalXMLEvent([]byte(xmlData))
+fmt.Printf("Extensions: %d\n", len(evt.Detail.Extensions))
+
+out, _ := evt.ToXML()
+fmt.Println(string(out))
 ```
 
 ### Type Validation and Catalog

--- a/event_pool.go
+++ b/event_pool.go
@@ -11,6 +11,9 @@ var eventPool = sync.Pool{
 
 func getEvent() *Event { return eventPool.Get().(*Event) }
 
+// ReleaseEvent returns an Event to the internal pool after resetting all fields.
+//
+// The provided pointer should no longer be used after calling this function.
 func ReleaseEvent(e *Event) {
 	if e == nil {
 		return

--- a/examples/chat_extension_example.go
+++ b/examples/chat_extension_example.go
@@ -1,0 +1,43 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/NERVsystems/cotlib"
+)
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cotlib.SetLogger(logger)
+
+	xmlInput := `<?xml version="1.0" encoding="UTF-8"?>
+<event version="2.0" uid="CHAT-1" type="t-x-c" time="2023-05-15T18:30:22Z" start="2023-05-15T18:30:22Z" stale="2023-05-15T18:30:32Z">
+  <point lat="0" lon="0" ce="9999999.0" le="9999999.0"/>
+  <detail>
+    <__chat message="Hello world!" sender="Alpha"/>
+  </detail>
+</event>`
+
+	evt, err := cotlib.UnmarshalXMLEvent([]byte(xmlInput))
+	if err != nil {
+		logger.Error("failed to parse event", "error", err)
+		return
+	}
+
+	for _, ext := range evt.Detail.Extensions {
+		fmt.Printf("Extension: %s\n", string(ext))
+	}
+
+	xmlOut, err := evt.ToXML()
+	if err != nil {
+		logger.Error("failed to serialize", "error", err)
+		return
+	}
+
+	fmt.Println(string(xmlOut))
+	cotlib.ReleaseEvent(evt)
+}


### PR DESCRIPTION
## Summary
- document extension round-trip support in `CHANGELOG.md`
- mention detail extensions in README
- expose `Detail.Extensions` for unknown XML
- add an example demonstrating a `__chat` detail element
- document `ReleaseEvent` function

## Testing
- `go test ./...`