### PR TITLE
Handle TAK detail extensions

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -538,8 +538,15 @@ type Contact struct {
 
 // Detail contains additional information about an event
 type Detail struct {
-	Group   *Group   `xml:"group,omitempty"`
-	Contact *Contact `xml:"contact,omitempty"`
+	Group             *Group             `xml:"group,omitempty"`
+	Contact           *Contact           `xml:"contact,omitempty"`
+	Chat              *Chat              `xml:"__chat,omitempty"`
+	ChatReceipt       *ChatReceipt       `xml:"__chatReceipt,omitempty"`
+	Geofence          *Geofence          `xml:"__geofence,omitempty"`
+	ServerDestination *ServerDestination `xml:"__serverdestination,omitempty"`
+	Video             *Video             `xml:"__video,omitempty"`
+	GroupExtension    *GroupExtension    `xml:"__group,omitempty"`
+	Unknown           []RawMessage       `xml:"-"`
 }
 
 // Group represents a group affiliation
@@ -553,6 +560,137 @@ type Link struct {
 	Uid      string `xml:"uid,attr"`
 	Type     string `xml:"type,attr"`
 	Relation string `xml:"relation,attr"`
+}
+
+// UnmarshalXML implements xml.Unmarshaler for Detail.
+func (d *Detail) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	*d = Detail{}
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "group":
+				var g Group
+				if err := dec.DecodeElement(&g, &t); err != nil {
+					return err
+				}
+				d.Group = &g
+			case "contact":
+				var c Contact
+				if err := dec.DecodeElement(&c, &t); err != nil {
+					return err
+				}
+				d.Contact = &c
+			case "__chat":
+				var c Chat
+				if err := dec.DecodeElement(&c, &t); err != nil {
+					return err
+				}
+				d.Chat = &c
+			case "__chatReceipt":
+				var c ChatReceipt
+				if err := dec.DecodeElement(&c, &t); err != nil {
+					return err
+				}
+				d.ChatReceipt = &c
+			case "__geofence":
+				var gf Geofence
+				if err := dec.DecodeElement(&gf, &t); err != nil {
+					return err
+				}
+				d.Geofence = &gf
+			case "__serverdestination":
+				var sd ServerDestination
+				if err := dec.DecodeElement(&sd, &t); err != nil {
+					return err
+				}
+				d.ServerDestination = &sd
+			case "__video":
+				var v Video
+				if err := dec.DecodeElement(&v, &t); err != nil {
+					return err
+				}
+				d.Video = &v
+			case "__group":
+				var gext GroupExtension
+				if err := dec.DecodeElement(&gext, &t); err != nil {
+					return err
+				}
+				d.GroupExtension = &gext
+			default:
+				raw, err := captureRaw(dec, t)
+				if err != nil {
+					return err
+				}
+				d.Unknown = append(d.Unknown, raw)
+			}
+		case xml.EndElement:
+			if t.Name == start.Name {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// MarshalXML implements xml.Marshaler for Detail.
+func (d *Detail) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	if err := enc.EncodeToken(start); err != nil {
+		return err
+	}
+	if d.Contact != nil {
+		if err := enc.Encode(d.Contact); err != nil {
+			return err
+		}
+	}
+	if d.Group != nil {
+		if err := enc.Encode(d.Group); err != nil {
+			return err
+		}
+	}
+	if d.Chat != nil {
+		if err := encodeRaw(enc, d.Chat.Raw); err != nil {
+			return err
+		}
+	}
+	if d.ChatReceipt != nil {
+		if err := encodeRaw(enc, d.ChatReceipt.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Geofence != nil {
+		if err := encodeRaw(enc, d.Geofence.Raw); err != nil {
+			return err
+		}
+	}
+	if d.ServerDestination != nil {
+		if err := encodeRaw(enc, d.ServerDestination.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Video != nil {
+		if err := encodeRaw(enc, d.Video.Raw); err != nil {
+			return err
+		}
+	}
+	if d.GroupExtension != nil {
+		if err := encodeRaw(enc, d.GroupExtension.Raw); err != nil {
+			return err
+		}
+	}
+	for _, raw := range d.Unknown {
+		if err := encodeRaw(enc, raw); err != nil {
+			return err
+		}
+	}
+	return enc.EncodeToken(start.End())
 }
 
 // NewEvent creates a new CoT event with the given parameters
@@ -1036,6 +1174,41 @@ func (e *Event) ToXML() ([]byte, error) {
 				buf.WriteByte('"')
 			}
 			buf.WriteString("/>\n")
+		}
+		if e.Detail.Chat != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.Chat.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.ChatReceipt != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.ChatReceipt.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.Geofence != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.Geofence.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.ServerDestination != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.ServerDestination.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.Video != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.Video.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.GroupExtension != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.GroupExtension.Raw)
+			buf.WriteByte('\n')
+		}
+		for _, raw := range e.Detail.Unknown {
+			buf.WriteString("    ")
+			buf.Write(raw)
+			buf.WriteByte('\n')
 		}
 		buf.WriteString("  </detail>\n")
 	}

--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -1,0 +1,166 @@
+package cotlib
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+)
+
+// RawMessage represents raw XML data preserved during decoding.
+type RawMessage []byte
+
+// Chat represents the TAK __chat extension.
+type Chat struct {
+	Raw RawMessage
+}
+
+// ChatReceipt represents the TAK __chatReceipt extension.
+type ChatReceipt struct {
+	Raw RawMessage
+}
+
+// Geofence represents the TAK __geofence extension.
+type Geofence struct {
+	Raw RawMessage
+}
+
+// ServerDestination represents the TAK __serverdestination extension.
+type ServerDestination struct {
+	Raw RawMessage
+}
+
+// Video represents the TAK __video extension.
+type Video struct {
+	Raw RawMessage
+}
+
+// GroupExtension represents the TAK __group extension.
+type GroupExtension struct {
+	Raw RawMessage
+}
+
+// captureRaw reads an element starting from start and returns its raw XML
+// representation.
+func captureRaw(dec *xml.Decoder, start xml.StartElement) (RawMessage, error) {
+	var buf bytes.Buffer
+	enc := xml.NewEncoder(&buf)
+	if err := enc.EncodeToken(start); err != nil {
+		return nil, err
+	}
+	depth := 1
+	for depth > 0 {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		switch tok.(type) {
+		case xml.StartElement:
+			depth++
+		case xml.EndElement:
+			depth--
+		}
+		if err := enc.EncodeToken(tok); err != nil {
+			return nil, err
+		}
+	}
+	if err := enc.Flush(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (c *Chat) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	c.Raw = raw
+	return nil
+}
+
+func (c Chat) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, c.Raw)
+}
+
+func (c *ChatReceipt) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	c.Raw = raw
+	return nil
+}
+
+func (c ChatReceipt) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, c.Raw)
+}
+
+func (g *Geofence) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	g.Raw = raw
+	return nil
+}
+
+func (g Geofence) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, g.Raw)
+}
+
+func (sd *ServerDestination) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	sd.Raw = raw
+	return nil
+}
+
+func (sd ServerDestination) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, sd.Raw)
+}
+
+func (v *Video) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	v.Raw = raw
+	return nil
+}
+
+func (v Video) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, v.Raw)
+}
+
+func (g *GroupExtension) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	g.Raw = raw
+	return nil
+}
+
+func (g GroupExtension) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, g.Raw)
+}
+
+// encodeRaw writes pre-encoded XML directly to the encoder.
+func encodeRaw(enc *xml.Encoder, raw RawMessage) error {
+	dec := xml.NewDecoder(bytes.NewReader(raw))
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if err := enc.EncodeToken(tok); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- preserve unknown detail extension elements for round-trip
- implement `Chat`, `ChatReceipt`, `Geofence`, `ServerDestination`, `Video`, and `GroupExtension`
- update XML marshaling/unmarshalling to keep raw unknown data
- support emitting extensions and unknown elements in `Event.ToXML`
- test round trip with chat extensions

## Testing
- `go vet ./...`
- `go test ./...`
