### PR TITLE
Document TAK detail extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,23 +135,32 @@ func main() {
 #### Handling Detail Extensions
 
 CoT events often include TAK-specific extensions inside the `<detail>` element.
-Unknown elements are preserved in `Detail.Unknown` and serialized back
-verbatim:
+`cotlib` now preserves several common extensions and round-trips them
+unchanged:
+
+- `__chat`
+- `__chatReceipt`
+- `__geofence`
+- `__serverdestination`
+- `__video`
+- `__group`
+
+Any unknown elements are stored in `Detail.Unknown` and serialized back
+verbatim.
 
 ```go
 xmlData := `<?xml version="1.0"?>
-<event version="2.0" uid="CHAT-1" type="t-x-c" time="2023-05-15T18:30:22Z" start="2023-05-15T18:30:22Z" stale="2023-05-15T18:30:32Z">
+<event version="2.0" uid="EXT-1" type="t-x-c" time="2023-05-15T18:30:22Z" start="2023-05-15T18:30:22Z" stale="2023-05-15T18:30:32Z">
   <point lat="0" lon="0" ce="9999999.0" le="9999999.0"/>
   <detail>
     <__chat message="Hello world!" sender="Alpha"/>
+    <__video url="http://example/video"/>
   </detail>
 </event>`
 
 evt, _ := cotlib.UnmarshalXMLEvent([]byte(xmlData))
-fmt.Printf("Extensions: %d\n", len(evt.Detail.Unknown))
-
 out, _ := evt.ToXML()
-fmt.Println(string(out))
+fmt.Println(string(out)) // prints the same XML
 ```
 
 ### Type Validation and Catalog

--- a/examples/chat_extension_example.go
+++ b/examples/chat_extension_example.go
@@ -19,6 +19,7 @@ func main() {
   <point lat="0" lon="0" ce="9999999.0" le="9999999.0"/>
   <detail>
     <__chat message="Hello world!" sender="Alpha"/>
+    <__video url="http://example/video"/>
   </detail>
 </event>`
 
@@ -28,8 +29,11 @@ func main() {
 		return
 	}
 
-	for _, ext := range evt.Detail.Unknown {
-		fmt.Printf("Extension: %s\n", string(ext))
+	if evt.Detail.Chat != nil {
+		fmt.Printf("Chat extension: %s\n", string(evt.Detail.Chat.Raw))
+	}
+	if evt.Detail.Video != nil {
+		fmt.Printf("Video extension: %s\n", string(evt.Detail.Video.Raw))
 	}
 
 	xmlOut, err := evt.ToXML()


### PR DESCRIPTION
## Summary
- document new TAK `detail` extensions in README
- show round-trip XML preservation example
- update chat example to include video extension

## Testing
- `go test -v ./...`