### PR TITLE
Add TAK detail extension support

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -546,6 +546,16 @@ type Detail struct {
 	ServerDestination *ServerDestination `xml:"__serverdestination,omitempty"`
 	Video             *Video             `xml:"__video,omitempty"`
 	GroupExtension    *GroupExtension    `xml:"__group,omitempty"`
+	Archive           *Archive           `xml:"archive,omitempty"`
+	AttachmentList    *AttachmentList    `xml:"attachmentList,omitempty"`
+	Environment       *Environment       `xml:"environment,omitempty"`
+	FileShare         *FileShare         `xml:"fileshare,omitempty"`
+	PrecisionLocation *PrecisionLocation `xml:"precisionlocation,omitempty"`
+	Takv              *Takv              `xml:"takv,omitempty"`
+	Track             *Track             `xml:"track,omitempty"`
+	Mission           *Mission           `xml:"mission,omitempty"`
+	Status            *Status            `xml:"status,omitempty"`
+	Shape             *Shape             `xml:"shape,omitempty"`
 	Unknown           []RawMessage       `xml:"-"`
 }
 
@@ -624,6 +634,66 @@ func (d *Detail) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 					return err
 				}
 				d.GroupExtension = &gext
+			case "archive":
+				var a Archive
+				if err := dec.DecodeElement(&a, &t); err != nil {
+					return err
+				}
+				d.Archive = &a
+			case "attachmentList":
+				var al AttachmentList
+				if err := dec.DecodeElement(&al, &t); err != nil {
+					return err
+				}
+				d.AttachmentList = &al
+			case "environment":
+				var env Environment
+				if err := dec.DecodeElement(&env, &t); err != nil {
+					return err
+				}
+				d.Environment = &env
+			case "fileshare":
+				var fs FileShare
+				if err := dec.DecodeElement(&fs, &t); err != nil {
+					return err
+				}
+				d.FileShare = &fs
+			case "precisionlocation":
+				var pl PrecisionLocation
+				if err := dec.DecodeElement(&pl, &t); err != nil {
+					return err
+				}
+				d.PrecisionLocation = &pl
+			case "takv":
+				var tv Takv
+				if err := dec.DecodeElement(&tv, &t); err != nil {
+					return err
+				}
+				d.Takv = &tv
+			case "track":
+				var tr Track
+				if err := dec.DecodeElement(&tr, &t); err != nil {
+					return err
+				}
+				d.Track = &tr
+			case "mission":
+				var m Mission
+				if err := dec.DecodeElement(&m, &t); err != nil {
+					return err
+				}
+				d.Mission = &m
+			case "status":
+				var s Status
+				if err := dec.DecodeElement(&s, &t); err != nil {
+					return err
+				}
+				d.Status = &s
+			case "shape":
+				var sh Shape
+				if err := dec.DecodeElement(&sh, &t); err != nil {
+					return err
+				}
+				d.Shape = &sh
 			default:
 				raw, err := captureRaw(dec, t)
 				if err != nil {
@@ -682,6 +752,56 @@ func (d *Detail) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	}
 	if d.GroupExtension != nil {
 		if err := encodeRaw(enc, d.GroupExtension.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Archive != nil {
+		if err := encodeRaw(enc, d.Archive.Raw); err != nil {
+			return err
+		}
+	}
+	if d.AttachmentList != nil {
+		if err := encodeRaw(enc, d.AttachmentList.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Environment != nil {
+		if err := encodeRaw(enc, d.Environment.Raw); err != nil {
+			return err
+		}
+	}
+	if d.FileShare != nil {
+		if err := encodeRaw(enc, d.FileShare.Raw); err != nil {
+			return err
+		}
+	}
+	if d.PrecisionLocation != nil {
+		if err := encodeRaw(enc, d.PrecisionLocation.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Takv != nil {
+		if err := encodeRaw(enc, d.Takv.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Track != nil {
+		if err := encodeRaw(enc, d.Track.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Mission != nil {
+		if err := encodeRaw(enc, d.Mission.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Status != nil {
+		if err := encodeRaw(enc, d.Status.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Shape != nil {
+		if err := encodeRaw(enc, d.Shape.Raw); err != nil {
 			return err
 		}
 	}
@@ -1203,6 +1323,56 @@ func (e *Event) ToXML() ([]byte, error) {
 		if e.Detail.GroupExtension != nil {
 			buf.WriteString("    ")
 			buf.Write(e.Detail.GroupExtension.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.Archive != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.Archive.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.AttachmentList != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.AttachmentList.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.Environment != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.Environment.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.FileShare != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.FileShare.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.PrecisionLocation != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.PrecisionLocation.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.Takv != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.Takv.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.Track != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.Track.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.Mission != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.Mission.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.Status != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.Status.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.Shape != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.Shape.Raw)
 			buf.WriteByte('\n')
 		}
 		for _, raw := range e.Detail.Unknown {

--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -39,6 +39,56 @@ type GroupExtension struct {
 	Raw RawMessage
 }
 
+// Archive represents the TAK archive extension.
+type Archive struct {
+	Raw RawMessage
+}
+
+// AttachmentList represents the TAK attachmentList extension.
+type AttachmentList struct {
+	Raw RawMessage
+}
+
+// Environment represents the TAK environment extension.
+type Environment struct {
+	Raw RawMessage
+}
+
+// FileShare represents the TAK fileshare extension.
+type FileShare struct {
+	Raw RawMessage
+}
+
+// PrecisionLocation represents the TAK precisionlocation extension.
+type PrecisionLocation struct {
+	Raw RawMessage
+}
+
+// Takv represents the TAK takv extension.
+type Takv struct {
+	Raw RawMessage
+}
+
+// Track represents the TAK track extension.
+type Track struct {
+	Raw RawMessage
+}
+
+// Mission represents the TAK mission extension.
+type Mission struct {
+	Raw RawMessage
+}
+
+// Status represents the TAK status extension.
+type Status struct {
+	Raw RawMessage
+}
+
+// Shape represents the TAK shape extension.
+type Shape struct {
+	Raw RawMessage
+}
+
 // captureRaw reads an element starting from start and returns its raw XML
 // representation.
 func captureRaw(dec *xml.Decoder, start xml.StartElement) (RawMessage, error) {
@@ -145,6 +195,136 @@ func (g *GroupExtension) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) 
 
 func (g GroupExtension) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	return encodeRaw(enc, g.Raw)
+}
+
+func (a *Archive) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	a.Raw = raw
+	return nil
+}
+
+func (a Archive) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, a.Raw)
+}
+
+func (a *AttachmentList) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	a.Raw = raw
+	return nil
+}
+
+func (a AttachmentList) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, a.Raw)
+}
+
+func (e *Environment) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	e.Raw = raw
+	return nil
+}
+
+func (e Environment) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, e.Raw)
+}
+
+func (f *FileShare) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	f.Raw = raw
+	return nil
+}
+
+func (f FileShare) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, f.Raw)
+}
+
+func (p *PrecisionLocation) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	p.Raw = raw
+	return nil
+}
+
+func (p PrecisionLocation) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, p.Raw)
+}
+
+func (t *Takv) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	t.Raw = raw
+	return nil
+}
+
+func (t Takv) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, t.Raw)
+}
+
+func (t *Track) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	t.Raw = raw
+	return nil
+}
+
+func (t Track) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, t.Raw)
+}
+
+func (m *Mission) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	m.Raw = raw
+	return nil
+}
+
+func (m Mission) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, m.Raw)
+}
+
+func (s *Status) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	s.Raw = raw
+	return nil
+}
+
+func (s Status) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, s.Raw)
+}
+
+func (s *Shape) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	s.Raw = raw
+	return nil
+}
+
+func (s Shape) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, s.Raw)
 }
 
 // encodeRaw writes pre-encoded XML directly to the encoder.

--- a/validation_test.go
+++ b/validation_test.go
@@ -309,3 +309,37 @@ func TestDetailExtensionsRoundTrip(t *testing.T) {
 	}
 	cotlib.ReleaseEvent(out)
 }
+
+func TestAdditionalDetailExtensionsRoundTrip(t *testing.T) {
+	evt, err := cotlib.NewEvent("X2", "a-f-G", 1, 2, 3)
+	if err != nil {
+		t.Fatalf("new event: %v", err)
+	}
+	evt.Detail = &cotlib.Detail{
+		Archive:           &cotlib.Archive{Raw: []byte(`<archive id="a"/>`)},
+		AttachmentList:    &cotlib.AttachmentList{Raw: []byte(`<attachmentList/>`)},
+		Environment:       &cotlib.Environment{Raw: []byte(`<environment/>`)},
+		FileShare:         &cotlib.FileShare{Raw: []byte(`<fileshare/>`)},
+		PrecisionLocation: &cotlib.PrecisionLocation{Raw: []byte(`<precisionlocation/>`)},
+		Takv:              &cotlib.Takv{Raw: []byte(`<takv/>`)},
+		Track:             &cotlib.Track{Raw: []byte(`<track/>`)},
+		Mission:           &cotlib.Mission{Raw: []byte(`<mission/>`)},
+		Status:            &cotlib.Status{Raw: []byte(`<status/>`)},
+		Shape:             &cotlib.Shape{Raw: []byte(`<shape/>`)},
+	}
+
+	xmlData, err := evt.ToXML()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	cotlib.ReleaseEvent(evt)
+
+	out, err := cotlib.UnmarshalXMLEvent(xmlData)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Detail == nil || out.Detail.Archive == nil || len(out.Detail.Archive.Raw) == 0 {
+		t.Errorf("archive extension lost")
+	}
+	cotlib.ReleaseEvent(out)
+}


### PR DESCRIPTION
## Summary
- support new raw detail extensions like archive, track, mission, etc.
- extend `Detail` struct and handle these in marshal/unmarshal and builder
- verify round trip for the additional extensions

## Testing
- `go test -v ./...`