### PR TITLE
Add RawMessage style extensions

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -556,6 +556,15 @@ type Detail struct {
 	Mission           *Mission           `xml:"mission,omitempty"`
 	Status            *Status            `xml:"status,omitempty"`
 	Shape             *Shape             `xml:"shape,omitempty"`
+	StrokeColor       *StrokeColor       `xml:"strokecolor,omitempty"`
+	StrokeWeight      *StrokeWeight      `xml:"strokeweight,omitempty"`
+	FillColor         *FillColor         `xml:"fillcolor,omitempty"`
+	LabelsOn          *LabelsOn          `xml:"labelson,omitempty"`
+	ColorExtension    *ColorExtension    `xml:"color,omitempty"`
+	UserIcon          *UserIcon          `xml:"usericon,omitempty"`
+	Bullseye          *Bullseye          `xml:"bullseye,omitempty"`
+	RouteInfo         *RouteInfo         `xml:"routeInfo,omitempty"`
+	Remarks           *Remarks           `xml:"remarks,omitempty"`
 	Unknown           []RawMessage       `xml:"-"`
 }
 
@@ -694,6 +703,60 @@ func (d *Detail) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 					return err
 				}
 				d.Shape = &sh
+			case "strokecolor":
+				var sc StrokeColor
+				if err := dec.DecodeElement(&sc, &t); err != nil {
+					return err
+				}
+				d.StrokeColor = &sc
+			case "strokeweight":
+				var sw StrokeWeight
+				if err := dec.DecodeElement(&sw, &t); err != nil {
+					return err
+				}
+				d.StrokeWeight = &sw
+			case "fillcolor":
+				var fc FillColor
+				if err := dec.DecodeElement(&fc, &t); err != nil {
+					return err
+				}
+				d.FillColor = &fc
+			case "labelson":
+				var lo LabelsOn
+				if err := dec.DecodeElement(&lo, &t); err != nil {
+					return err
+				}
+				d.LabelsOn = &lo
+			case "color":
+				var co ColorExtension
+				if err := dec.DecodeElement(&co, &t); err != nil {
+					return err
+				}
+				d.ColorExtension = &co
+			case "usericon":
+				var ui UserIcon
+				if err := dec.DecodeElement(&ui, &t); err != nil {
+					return err
+				}
+				d.UserIcon = &ui
+			case "bullseye":
+				var b Bullseye
+				if err := dec.DecodeElement(&b, &t); err != nil {
+					return err
+				}
+				d.Bullseye = &b
+			case "routeInfo":
+				var ri RouteInfo
+				if err := dec.DecodeElement(&ri, &t); err != nil {
+					return err
+				}
+				d.RouteInfo = &ri
+			case "remarks":
+				var r Remarks
+				if err := dec.DecodeElement(&r, &t); err != nil {
+					return err
+				}
+				d.Remarks = &r
 			default:
 				raw, err := captureRaw(dec, t)
 				if err != nil {
@@ -802,6 +865,51 @@ func (d *Detail) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	}
 	if d.Shape != nil {
 		if err := encodeRaw(enc, d.Shape.Raw); err != nil {
+			return err
+		}
+	}
+	if d.StrokeColor != nil {
+		if err := encodeRaw(enc, d.StrokeColor.Raw); err != nil {
+			return err
+		}
+	}
+	if d.StrokeWeight != nil {
+		if err := encodeRaw(enc, d.StrokeWeight.Raw); err != nil {
+			return err
+		}
+	}
+	if d.FillColor != nil {
+		if err := encodeRaw(enc, d.FillColor.Raw); err != nil {
+			return err
+		}
+	}
+	if d.LabelsOn != nil {
+		if err := encodeRaw(enc, d.LabelsOn.Raw); err != nil {
+			return err
+		}
+	}
+	if d.ColorExtension != nil {
+		if err := encodeRaw(enc, d.ColorExtension.Raw); err != nil {
+			return err
+		}
+	}
+	if d.UserIcon != nil {
+		if err := encodeRaw(enc, d.UserIcon.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Bullseye != nil {
+		if err := encodeRaw(enc, d.Bullseye.Raw); err != nil {
+			return err
+		}
+	}
+	if d.RouteInfo != nil {
+		if err := encodeRaw(enc, d.RouteInfo.Raw); err != nil {
+			return err
+		}
+	}
+	if d.Remarks != nil {
+		if err := encodeRaw(enc, d.Remarks.Raw); err != nil {
 			return err
 		}
 	}

--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -89,6 +89,51 @@ type Shape struct {
 	Raw RawMessage
 }
 
+// StrokeColor represents the TAK strokecolor extension.
+type StrokeColor struct {
+	Raw RawMessage
+}
+
+// StrokeWeight represents the TAK strokeweight extension.
+type StrokeWeight struct {
+	Raw RawMessage
+}
+
+// FillColor represents the TAK fillcolor extension.
+type FillColor struct {
+	Raw RawMessage
+}
+
+// LabelsOn represents the TAK labelson extension.
+type LabelsOn struct {
+	Raw RawMessage
+}
+
+// ColorExtension represents the TAK color extension.
+type ColorExtension struct {
+	Raw RawMessage
+}
+
+// UserIcon represents the TAK usericon extension.
+type UserIcon struct {
+	Raw RawMessage
+}
+
+// Bullseye represents the TAK bullseye extension.
+type Bullseye struct {
+	Raw RawMessage
+}
+
+// RouteInfo represents the TAK routeInfo extension.
+type RouteInfo struct {
+	Raw RawMessage
+}
+
+// Remarks represents the TAK remarks extension.
+type Remarks struct {
+	Raw RawMessage
+}
+
 // captureRaw reads an element starting from start and returns its raw XML
 // representation.
 func captureRaw(dec *xml.Decoder, start xml.StartElement) (RawMessage, error) {
@@ -325,6 +370,123 @@ func (s *Shape) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 
 func (s Shape) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	return encodeRaw(enc, s.Raw)
+}
+
+func (sc *StrokeColor) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	sc.Raw = raw
+	return nil
+}
+
+func (sc StrokeColor) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, sc.Raw)
+}
+
+func (sw *StrokeWeight) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	sw.Raw = raw
+	return nil
+}
+
+func (sw StrokeWeight) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, sw.Raw)
+}
+
+func (fc *FillColor) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	fc.Raw = raw
+	return nil
+}
+
+func (fc FillColor) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, fc.Raw)
+}
+
+func (lo *LabelsOn) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	lo.Raw = raw
+	return nil
+}
+
+func (lo LabelsOn) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, lo.Raw)
+}
+
+func (c *ColorExtension) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	c.Raw = raw
+	return nil
+}
+
+func (c ColorExtension) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, c.Raw)
+}
+
+func (ui *UserIcon) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	ui.Raw = raw
+	return nil
+}
+
+func (ui UserIcon) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, ui.Raw)
+}
+
+func (b *Bullseye) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	b.Raw = raw
+	return nil
+}
+
+func (b Bullseye) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, b.Raw)
+}
+
+func (ri *RouteInfo) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	ri.Raw = raw
+	return nil
+}
+
+func (ri RouteInfo) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, ri.Raw)
+}
+
+func (r *Remarks) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	raw, err := captureRaw(dec, start)
+	if err != nil {
+		return err
+	}
+	r.Raw = raw
+	return nil
+}
+
+func (r Remarks) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	return encodeRaw(enc, r.Raw)
 }
 
 // encodeRaw writes pre-encoded XML directly to the encoder.


### PR DESCRIPTION
## Summary
- support new `<detail>` style extensions by roundtripping XML
  - strokecolor, strokeweight, fillcolor, labelson
  - `<color>` element, usericon, bullseye, routeInfo, remarks
- update `Detail` struct and encode/decode logic

## Testing
- `go test -v ./...`