### PR TITLE
Add strokeColor/usericon round-trip example

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -519,6 +519,10 @@ type Event struct {
 	Point   Point    `xml:"point"`
 	Detail  *Detail  `xml:"detail,omitempty"`
 	Links   []Link   `xml:"link,omitempty"`
+	// StrokeColor is an ARGB hex color used for drawing events.
+	StrokeColor string `xml:"strokeColor,attr,omitempty"`
+	// UserIcon specifies a custom icon URL or resource for the event.
+	UserIcon string `xml:"usericon,attr,omitempty"`
 }
 
 // Error sentinels for validation
@@ -1241,6 +1245,16 @@ func (e *Event) ToXML() ([]byte, error) {
 	if !e.Stale.Time().IsZero() {
 		buf.WriteString(` stale="`)
 		buf.WriteString(e.Stale.Time().UTC().Format(CotTimeFormat))
+		buf.WriteByte('"')
+	}
+	if e.StrokeColor != "" {
+		buf.WriteString(` strokeColor="`)
+		buf.WriteString(escapeAttr(e.StrokeColor))
+		buf.WriteByte('"')
+	}
+	if e.UserIcon != "" {
+		buf.WriteString(` usericon="`)
+		buf.WriteString(escapeAttr(e.UserIcon))
 		buf.WriteByte('"')
 	}
 	buf.WriteString(">\n")

--- a/examples/stroke_usericon_example.go
+++ b/examples/stroke_usericon_example.go
@@ -1,0 +1,41 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/NERVsystems/cotlib"
+)
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cotlib.SetLogger(logger)
+
+	evt, err := cotlib.NewEvent("EXAMPLE-1", "u-d-p", 34.0, -117.0, 0)
+	if err != nil {
+		logger.Error("new event", "err", err)
+		return
+	}
+	evt.StrokeColor = "#ff0000ff"
+	evt.UserIcon = "http://example.com/icon.png"
+
+	xmlData, err := evt.ToXML()
+	if err != nil {
+		logger.Error("marshal", "err", err)
+		return
+	}
+	fmt.Println(string(xmlData))
+
+	out, err := cotlib.UnmarshalXMLEvent(xmlData)
+	if err != nil {
+		logger.Error("unmarshal", "err", err)
+		return
+	}
+	fmt.Printf("StrokeColor: %s\n", out.StrokeColor)
+	fmt.Printf("UserIcon: %s\n", out.UserIcon)
+	cotlib.ReleaseEvent(evt)
+	cotlib.ReleaseEvent(out)
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,6 +1,7 @@
 package cotlib_test
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 
@@ -217,4 +218,24 @@ func ExampleFindTypesByFullName() {
 	// Found type: a-h-G-E-X-N (Gnd/Equip/Nbc Equipment)
 	// Found type: a-n-G-E-X-N (Gnd/Equip/Nbc Equipment)
 	// Found type: a-u-G-E-X-N (Gnd/Equip/Nbc Equipment)
+}
+
+func Example_roundTripStrokeColorUsericon() {
+	evt, _ := cotlib.NewEvent("EX-UI", "a-f-G", 0, 0, 0)
+	evt.StrokeColor = "ff0000ff"
+	evt.UserIcon = "icon.png"
+
+	xmlData, _ := evt.ToXML()
+	cotlib.ReleaseEvent(evt)
+
+	out, _ := cotlib.UnmarshalXMLEvent(xmlData)
+	fmt.Printf("strokeColor: %s\n", out.StrokeColor)
+	fmt.Printf("usericon: %s\n", out.UserIcon)
+	outXML, _ := out.ToXML()
+	fmt.Printf("round-trip equal: %v\n", bytes.Equal(xmlData, outXML))
+	cotlib.ReleaseEvent(out)
+	// Output:
+	// strokeColor: ff0000ff
+	// usericon: icon.png
+	// round-trip equal: true
 }


### PR DESCRIPTION
## Summary
- support `strokeColor` and `usericon` attributes on `Event`
- example program demonstrating usage
- add example test verifying round-trip preservation

## Testing
- `go test -v ./...`
