### PR TITLE
Fix wildcard validation

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -859,12 +859,16 @@ func ValidateType(typ string) error {
 		if len(parts) < 2 {
 			return fmt.Errorf("invalid type format")
 		}
-		// Only allow wildcards at the end of the type string
-		for i := 0; i < len(parts)-1; i++ {
-			if parts[i] == "*" {
-				return fmt.Errorf("wildcard only allowed at end of type")
+
+		// Only allow a trailing segment consisting solely of '*'
+		for i, p := range parts {
+			if strings.Contains(p, "*") {
+				if p != "*" || i != len(parts)-1 {
+					return fmt.Errorf("wildcard only allowed at end of type")
+				}
 			}
 		}
+
 		// Validate the prefix
 		if parts[0] != "a" && parts[0] != "b" && parts[0] != "t" {
 			return fmt.Errorf("invalid type prefix")

--- a/test/validation/validation_test.go
+++ b/test/validation/validation_test.go
@@ -263,6 +263,16 @@ func TestWildcardPatterns(t *testing.T) {
 			pattern: "a-f-G-U-*-C",
 			wantErr: true,
 		},
+		{
+			name:    "embedded wildcard segment",
+			pattern: "a-f*G",
+			wantErr: true,
+		},
+		{
+			name:    "embedded wildcard final segment",
+			pattern: "a-f-G*X",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/validation_test.go
+++ b/validation_test.go
@@ -15,6 +15,8 @@ func TestWildcardPatterns(t *testing.T) {
 		{"valid wildcard", "a-f-G-U-C-*", true},
 		{"invalid wildcard", "a-f-G-U-C-", false},
 		{"invalid wildcard position", "a-f-G-U-*-C", false},
+		{"embedded wildcard segment", "a-f*G", false},
+		{"embedded wildcard final segment", "a-f-G*X", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- reject embedded '*' in ValidateType
- add tests for invalid wildcard patterns

## Testing
- `go test ./...`
