### PR TITLE
Add ErrInvalidLongitude sentinel and update validation

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -527,9 +527,10 @@ type Event struct {
 
 // Error sentinels for validation
 var (
-	ErrInvalidInput    = fmt.Errorf("invalid input")
-	ErrInvalidLatitude = fmt.Errorf("invalid latitude")
-	ErrInvalidUID      = fmt.Errorf("invalid UID")
+	ErrInvalidInput     = fmt.Errorf("invalid input")
+	ErrInvalidLatitude  = fmt.Errorf("invalid latitude")
+	ErrInvalidLongitude = fmt.Errorf("invalid longitude")
+	ErrInvalidUID       = fmt.Errorf("invalid UID")
 )
 
 // doctypePattern matches XML DOCTYPE declarations case-insensitively
@@ -1284,7 +1285,7 @@ func ValidateLatLon(lat, lon float64) error {
 		return ErrInvalidLatitude
 	}
 	if lon < -180 || lon > 180 {
-		return fmt.Errorf("invalid longitude")
+		return ErrInvalidLongitude
 	}
 	return nil
 }

--- a/test/validation/validation_test.go
+++ b/test/validation/validation_test.go
@@ -141,6 +141,11 @@ func TestValidationBaseline(t *testing.T) {
 		if !errors.Is(err, cotlib.ErrInvalidLatitude) {
 			t.Error("Expected ErrInvalidLatitude")
 		}
+
+		err = cotlib.ValidateLatLon(0, 181)
+		if !errors.Is(err, cotlib.ErrInvalidLongitude) {
+			t.Error("Expected ErrInvalidLongitude")
+		}
 	})
 
 	t.Run("uid_validation", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- declare `ErrInvalidLongitude`
- return `ErrInvalidLongitude` from `ValidateLatLon`
- extend sentinel tests to check for the new error

## Testing
- `go test ./...`
