### PR TITLE
Add dot wildcard resolution in type validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ The library enforces strict validation of CoT types:
 - Length limits
 - Wildcard pattern validation
 - Type catalog verification
+- Automatic resolution of `f`, `h`, `n`, or `u` segments to catalog
+  entries containing `.`
 
 ```go
 // Examples of different validation scenarios:

--- a/cotlib_test.go
+++ b/cotlib_test.go
@@ -556,6 +556,22 @@ func TestRegisterCoTType(t *testing.T) {
 	}
 }
 
+func TestValidateTypeDotWildcard(t *testing.T) {
+	// Register a type that uses '.' as a wildcard for affiliation
+	wildcardType := "a-.-Z"
+	RegisterCoTType(wildcardType)
+
+	if err := ValidateType("a-f-Z"); err != nil {
+		t.Errorf("ValidateType failed wildcard resolution: %v", err)
+	}
+}
+
+func TestValidateTypeDotWildcardNegative(t *testing.T) {
+	if err := ValidateType("a-f-nonexistent"); err == nil {
+		t.Error("expected validation to fail for missing wildcard match")
+	}
+}
+
 func TestEmbeddedTypesValidation(t *testing.T) {
 	// Test common tactical types
 	tacticalTypes := []string{


### PR DESCRIPTION
## Summary
- enhance ValidateType to handle wildcard resolution via '.' segments
- document the wildcard resolution behavior
- add unit tests for dot wildcard substitution

## Testing
- `go test -v ./...`