### PR TITLE
Handle nil event in validation helpers

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -1573,7 +1573,12 @@ func (e *Event) ToXML() ([]byte, error) {
 
 // SetEventHowFromDescriptor sets the how field on an event using a descriptor.
 // For example: SetEventHowFromDescriptor(event, "gps") sets how to "h-g-i-g-o".
+// It returns an error if event is nil or the descriptor is invalid.
 func SetEventHowFromDescriptor(event *Event, descriptor string) error {
+	if event == nil {
+		return fmt.Errorf("nil event")
+	}
+
 	howValue, err := cottypes.GetHowValue(descriptor)
 	if err != nil {
 		return fmt.Errorf("failed to get how value for descriptor %s: %w", descriptor, err)
@@ -1583,7 +1588,12 @@ func SetEventHowFromDescriptor(event *Event, descriptor string) error {
 }
 
 // AddValidatedLink adds a link to the event after validating the relation and type.
+// It returns an error if called on a nil Event.
 func (e *Event) AddValidatedLink(uid, linkType, relation string) error {
+	if e == nil {
+		return fmt.Errorf("nil event")
+	}
+
 	if err := ValidateType(linkType); err != nil {
 		return fmt.Errorf("invalid link type: %w", err)
 	}

--- a/validation_test.go
+++ b/validation_test.go
@@ -197,6 +197,12 @@ func TestSetEventHowFromDescriptor(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("nil_event", func(t *testing.T) {
+		if err := cotlib.SetEventHowFromDescriptor(nil, "gps"); err == nil {
+			t.Error("Expected error for nil event, but got none")
+		}
+	})
 }
 
 // TestAddValidatedLink tests the AddValidatedLink method.
@@ -229,6 +235,13 @@ func TestAddValidatedLink(t *testing.T) {
 		err := event.AddValidatedLink("test-uid", "a-f-G", "invalid-relation")
 		if err == nil {
 			t.Error("Expected error for invalid relation, but got none")
+		}
+	})
+
+	t.Run("nil_event", func(t *testing.T) {
+		var nilEvent *cotlib.Event
+		if err := nilEvent.AddValidatedLink("uid", "a-f-G", "c"); err == nil {
+			t.Error("Expected error for nil event, but got none")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- prevent panic on nil event in `SetEventHowFromDescriptor` and `AddValidatedLink`
- update docs for the new behaviour
- test nil event cases for both helpers

## Testing
- `go test -v ./...`
