### PR TITLE
feat(validation): add sentinel errors for how/type/relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ func main() {
 package main
 
 import (
+    "errors"
     "fmt"
     "github.com/NERVsystems/cotlib"
 )
@@ -189,6 +190,7 @@ The library provides comprehensive type validation and catalog management:
 package main
 
 import (
+    "errors"
     "fmt"
     "log"
     "github.com/NERVsystems/cotlib"
@@ -202,7 +204,9 @@ func main() {
 
     // Validate a CoT type
     if err := cotlib.ValidateType("a-f-G-U-C-F"); err != nil {
-        log.Fatal(err)
+        if errors.Is(err, cotlib.ErrInvalidType) {
+            log.Fatal(err)
+        }
     }
 
     // Look up type metadata
@@ -269,7 +273,9 @@ How values indicate the source or method of position determination:
 package main
 
 import (
+    "errors"
     "fmt"
+    "log"
     "github.com/NERVsystems/cotlib"
 )
 
@@ -289,7 +295,9 @@ func main() {
     
     // Validate how value
     if err := cotlib.ValidateHow(event.How); err != nil {
-        log.Fatal(err)
+        if errors.Is(err, cotlib.ErrInvalidHow) {
+            log.Fatal(err)
+        }
     }
     
     // Get human-readable description
@@ -306,7 +314,9 @@ Relation values specify the relationship type in link elements:
 // Add a validated link with parent-point relation
 err := event.AddValidatedLink("HQ-1", "a-f-G-U-C", "p-p")
 if err != nil {
-    log.Fatal(err)
+    if errors.Is(err, cotlib.ErrInvalidRelation) {
+        log.Fatal(err)
+    }
 }
 
 // Or add manually (validation happens during event.Validate())
@@ -315,6 +325,13 @@ event.AddLink(&cotlib.Link{
     Type:     "a-f-G",
     Relation: "p-c", // parent-child
 })
+
+// Validate relation value
+if err := cotlib.ValidateRelation("p-c"); err != nil {
+    if errors.Is(err, cotlib.ErrInvalidRelation) {
+        log.Fatal(err)
+    }
+}
 
 // Get relation description
 desc, _ := cotlib.GetRelationDescription("p-p")

--- a/cotlib_test.go
+++ b/cotlib_test.go
@@ -2,6 +2,7 @@ package cotlib
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"strings"
@@ -519,6 +520,9 @@ func TestValidateType(t *testing.T) {
 					t.Logf("Error: %v", err)
 				}
 			}
+			if err != nil && !errors.Is(err, ErrInvalidType) {
+				t.Errorf("error does not wrap ErrInvalidType: %v", err)
+			}
 		})
 	}
 }
@@ -923,7 +927,7 @@ func TestValidateTypeWildcardResolution(t *testing.T) {
 			name:    "invalid atomic wildcard should fail",
 			typ:     "b-.-G",
 			wantErr: true,
-			errMsg:  "unknown type",
+			errMsg:  "",
 		},
 	}
 
@@ -933,8 +937,8 @@ func TestValidateTypeWildcardResolution(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("ValidateType(%q) expected error but got none", tt.typ)
-				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
-					t.Errorf("ValidateType(%q) error = %v, want error containing %q", tt.typ, err, tt.errMsg)
+				} else if !errors.Is(err, ErrInvalidType) {
+					t.Errorf("error does not wrap ErrInvalidType: %v", err)
 				}
 			} else {
 				if err != nil {

--- a/validation_test.go
+++ b/validation_test.go
@@ -2,6 +2,7 @@ package cotlib_test
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/NERVsystems/cotlib"
@@ -51,11 +52,16 @@ func TestValidateHow(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := cotlib.ValidateHow(tc.how)
-			if tc.expectErr && err == nil {
-				t.Errorf("Expected error for how value %s, but got none", tc.how)
-			}
-			if !tc.expectErr && err != nil {
-				t.Errorf("Expected no error for how value %s, but got: %v", tc.how, err)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error for how value %s, but got none", tc.how)
+				} else if !errors.Is(err, cotlib.ErrInvalidHow) {
+					t.Errorf("error does not wrap ErrInvalidHow: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error for how value %s, but got: %v", tc.how, err)
+				}
 			}
 		})
 	}
@@ -80,11 +86,16 @@ func TestValidateRelation(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := cotlib.ValidateRelation(tc.relation)
-			if tc.expectErr && err == nil {
-				t.Errorf("Expected error for relation value %s, but got none", tc.relation)
-			}
-			if !tc.expectErr && err != nil {
-				t.Errorf("Expected no error for relation value %s, but got: %v", tc.relation, err)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error for relation value %s, but got none", tc.relation)
+				} else if !errors.Is(err, cotlib.ErrInvalidRelation) {
+					t.Errorf("error does not wrap ErrInvalidRelation: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error for relation value %s, but got: %v", tc.relation, err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add `ErrInvalidType`, `ErrInvalidHow`, and `ErrInvalidRelation`
- wrap new sentinels in validation helpers
- show usage of `errors.Is` in README examples
- adjust unit tests to assert sentinel wrapping

## Testing
- `go test ./...`