### PR TITLE
Add chat schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ unchanged:
 - `status`
 - `shape`
 
+The `__chat` and `__chatReceipt` extensions are validated against embedded
+XML schemas when decoding and during event validation. Invalid chat XML will
+cause an error.
+
 Example: adding a `shape` extension with a `strokeColor` attribute:
 
 ```go

--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -3,6 +3,7 @@ package cotlib
 import (
 	"bytes"
 	"encoding/xml"
+	"github.com/NERVsystems/cotlib/validator"
 	"io"
 )
 
@@ -10,13 +11,19 @@ import (
 type RawMessage []byte
 
 // Chat represents the TAK __chat extension.
+// Chat represents the TAK __chat extension with basic attributes.
 type Chat struct {
-	Raw RawMessage
+	XMLName xml.Name `xml:"__chat"`
+	ID      string   `xml:"id,attr,omitempty"`
+	Message string   `xml:"message,attr,omitempty"`
+	Sender  string   `xml:"sender,attr,omitempty"`
 }
 
 // ChatReceipt represents the TAK __chatReceipt extension.
+// ChatReceipt represents the TAK __chatReceipt extension.
 type ChatReceipt struct {
-	Raw RawMessage
+	XMLName xml.Name `xml:"__chatReceipt"`
+	Ack     string   `xml:"ack,attr"`
 }
 
 // Geofence represents the TAK __geofence extension.
@@ -169,12 +176,11 @@ func (c *Chat) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	if err != nil {
 		return err
 	}
-	c.Raw = raw
-	return nil
-}
-
-func (c Chat) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
-	return encodeRaw(enc, c.Raw)
+	if err := validator.ValidateAgainstSchema("chat", raw); err != nil {
+		return err
+	}
+	type alias Chat
+	return xml.Unmarshal(raw, (*alias)(c))
 }
 
 func (c *ChatReceipt) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
@@ -182,12 +188,11 @@ func (c *ChatReceipt) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) err
 	if err != nil {
 		return err
 	}
-	c.Raw = raw
-	return nil
-}
-
-func (c ChatReceipt) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
-	return encodeRaw(enc, c.Raw)
+	if err := validator.ValidateAgainstSchema("chatReceipt", raw); err != nil {
+		return err
+	}
+	type alias ChatReceipt
+	return xml.Unmarshal(raw, (*alias)(c))
 }
 
 func (g *Geofence) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {

--- a/examples/chat_extension_example.go
+++ b/examples/chat_extension_example.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	if evt.Detail.Chat != nil {
-		fmt.Printf("Chat extension: %s\n", string(evt.Detail.Chat.Raw))
+		fmt.Printf("Chat from %s: %s\n", evt.Detail.Chat.Sender, evt.Detail.Chat.Message)
 	}
 	if evt.Detail.Video != nil {
 		fmt.Printf("Video extension: %s\n", string(evt.Detail.Video.Raw))

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -1,0 +1,82 @@
+package validator
+
+/*
+#cgo pkg-config: libxml-2.0
+#include <libxml/parser.h>
+#include <libxml/xmlschemas.h>
+#include <stdlib.h>
+
+static xmlSchemaPtr compileSchema(const char* buf, int size) {
+    xmlSchemaParserCtxtPtr ctxt = xmlSchemaNewMemParserCtxt(buf, size);
+    if (ctxt == NULL) {
+        return NULL;
+    }
+    xmlSchemaPtr schema = xmlSchemaParse(ctxt);
+    xmlSchemaFreeParserCtxt(ctxt);
+    return schema;
+}
+
+static int validateDoc(xmlSchemaPtr schema, const char* docbuf, int size) {
+    xmlDocPtr doc = xmlReadMemory(docbuf, size, "noname.xml", NULL, 0);
+    if (doc == NULL) {
+        return -1;
+    }
+    xmlSchemaValidCtxtPtr vctxt = xmlSchemaNewValidCtxt(schema);
+    int ret = xmlSchemaValidateDoc(vctxt, doc);
+    xmlSchemaFreeValidCtxt(vctxt);
+    xmlFreeDoc(doc);
+    return ret;
+}
+
+static void freeSchema(xmlSchemaPtr schema) {
+    if (schema) xmlSchemaFree(schema);
+}
+*/
+import "C"
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+)
+
+// Schema wraps a compiled XML Schema.
+type Schema struct {
+	ptr *C.xmlSchema
+}
+
+// Compile compiles raw XSD bytes into a Schema.
+func Compile(data []byte) (*Schema, error) {
+	if len(data) == 0 {
+		return nil, errors.New("empty schema")
+	}
+	ptr := C.compileSchema((*C.char)(unsafe.Pointer(&data[0])), C.int(len(data)))
+	if ptr == nil {
+		return nil, errors.New("failed to compile schema")
+	}
+	s := &Schema{ptr: ptr}
+	runtime.SetFinalizer(s, func(sc *Schema) { sc.Free() })
+	return s, nil
+}
+
+// Validate validates XML bytes against the schema.
+func (s *Schema) Validate(xml []byte) error {
+	if s.ptr == nil {
+		return errors.New("schema not initialized")
+	}
+	if len(xml) == 0 {
+		return errors.New("empty xml")
+	}
+	ret := C.validateDoc(s.ptr, (*C.char)(unsafe.Pointer(&xml[0])), C.int(len(xml)))
+	if ret != 0 {
+		return errors.New("validation failed")
+	}
+	return nil
+}
+
+// Free releases resources associated with the schema.
+func (s *Schema) Free() {
+	if s.ptr != nil {
+		C.freeSchema(s.ptr)
+		s.ptr = nil
+	}
+}

--- a/validator/schemas/chat.xsd
+++ b/validator/schemas/chat.xsd
@@ -1,0 +1,9 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="__chat">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:string" use="optional"/>
+      <xs:attribute name="message" type="xs:string" use="optional"/>
+      <xs:attribute name="sender" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/validator/schemas/chatReceipt.xsd
+++ b/validator/schemas/chatReceipt.xsd
@@ -1,0 +1,7 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="__chatReceipt">
+    <xs:complexType>
+      <xs:attribute name="ack" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,0 +1,43 @@
+package validator
+
+import (
+	_ "embed"
+	"fmt"
+	"sync"
+)
+
+//go:embed schemas/chat.xsd
+var chatXSD []byte
+
+//go:embed schemas/chatReceipt.xsd
+var chatReceiptXSD []byte
+
+var (
+	schemas map[string]*Schema
+	once    sync.Once
+)
+
+func initSchemas() {
+	schemas = make(map[string]*Schema)
+	chat, err := Compile(chatXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile chat schema: %w", err))
+	}
+	schemas["chat"] = chat
+
+	receipt, err := Compile(chatReceiptXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile chatReceipt schema: %w", err))
+	}
+	schemas["chatReceipt"] = receipt
+}
+
+// ValidateAgainstSchema validates XML against a named schema.
+func ValidateAgainstSchema(name string, xml []byte) error {
+	once.Do(initSchemas)
+	s, ok := schemas[name]
+	if !ok {
+		return fmt.Errorf("unknown schema %s", name)
+	}
+	return s.Validate(xml)
+}


### PR DESCRIPTION
## Summary
- create `validator` package to compile chat XML schemas with libxml2
- validate `Chat` and `ChatReceipt` details against their schemas
- enforce chat validation in `Event.ValidateAt`
- update examples and documentation
- add tests for schema validation

## Testing
- `go test ./...`