### PR TITLE
feat(validation): add chat validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Detail extensions with round-trip preservation in `Detail.Unknown`
+- Validator package with schema checks for `__chat` extensions
 
 ### Changed
 - Allowed `HAE` sentinel value `9999999.0` and expanded valid range to -12000..40000000

--- a/README.md
+++ b/README.md
@@ -182,6 +182,13 @@ out, _ := evt.ToXML()
 fmt.Println(string(out)) // prints the same XML
 ```
 
+### Validator Package
+
+The optional `validator` subpackage provides schema checks for common detail
+extensions. `validator.ValidateChat` ensures a `__chat` element contains both
+`sender` and `message` attributes. `Event.Validate` calls this automatically
+when a chat extension is present.
+
 ### Type Validation and Catalog
 
 The library provides comprehensive type validation and catalog management:

--- a/cotlib.go
+++ b/cotlib.go
@@ -88,6 +88,7 @@ import (
 	"github.com/NERVsystems/cotlib/ctxlog"
 
 	"github.com/NERVsystems/cotlib/cottypes"
+	"github.com/NERVsystems/cotlib/validator"
 )
 
 // Security limits for XML parsing and validation
@@ -1145,6 +1146,13 @@ func (e *Event) ValidateAt(now time.Time) error {
 	// Validate point
 	if err := e.Point.Validate(); err != nil {
 		return err
+	}
+
+	// Validate chat extension if present
+	if e.Detail != nil && e.Detail.Chat != nil {
+		if err := validator.ValidateChat(e.Detail.Chat.Raw); err != nil {
+			return fmt.Errorf("chat validation failed: %w", err)
+		}
 	}
 
 	return nil

--- a/validator/chat.go
+++ b/validator/chat.go
@@ -1,0 +1,29 @@
+package validator
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// ChatSchema defines the expected attributes for the __chat extension.
+type ChatSchema struct {
+	XMLName xml.Name `xml:"__chat"`
+	ID      string   `xml:"id,attr,omitempty"`
+	Message string   `xml:"message,attr"`
+	Sender  string   `xml:"sender,attr"`
+}
+
+// ValidateChat parses and validates a __chat extension.
+func ValidateChat(data []byte) error {
+	var c ChatSchema
+	if err := xml.Unmarshal(data, &c); err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	if c.Message == "" {
+		return fmt.Errorf("missing message: %w", ErrInvalidChat)
+	}
+	if c.Sender == "" {
+		return fmt.Errorf("missing sender: %w", ErrInvalidChat)
+	}
+	return nil
+}

--- a/validator/chat_test.go
+++ b/validator/chat_test.go
@@ -1,0 +1,19 @@
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/NERVsystems/cotlib/validator"
+)
+
+func TestValidateChat(t *testing.T) {
+	valid := []byte(`<__chat sender="Alice" message="hello"/>`)
+	if err := validator.ValidateChat(valid); err != nil {
+		t.Fatalf("valid chat rejected: %v", err)
+	}
+
+	invalid := []byte(`<__chat sender="Alice"/>`)
+	if err := validator.ValidateChat(invalid); err == nil {
+		t.Fatal("expected error for missing message")
+	}
+}

--- a/validator/errors.go
+++ b/validator/errors.go
@@ -1,0 +1,6 @@
+package validator
+
+import "errors"
+
+// ErrInvalidChat indicates the chat extension does not conform to the schema.
+var ErrInvalidChat = errors.New("invalid chat")


### PR DESCRIPTION
## Summary
- create `validator` package
- validate `__chat` extensions against schema
- document validator usage
- enforce chat schema in event validation
- test chat validator

## Testing
- `go test ./...`