### PR TITLE
Add embedded schema validation for chat extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ fmt.Println(string(out)) // prints the same XML
 ### Validator Package
 
 The optional `validator` subpackage provides schema checks for common detail
-extensions. `validator.ValidateChat` ensures a `__chat` element contains both
-`sender` and `message` attributes. `Event.Validate` calls this automatically
-when a chat extension is present.
+extensions. `validator.ValidateAgainstSchema` validates XML against embedded
+XSD files. `Event.Validate` automatically checks `__chat` and `__chatReceipt`
+extensions using these schemas.
 
 ### Type Validation and Catalog
 

--- a/cotlib.go
+++ b/cotlib.go
@@ -1148,10 +1148,25 @@ func (e *Event) ValidateAt(now time.Time) error {
 		return err
 	}
 
-	// Validate chat extension if present
-	if e.Detail != nil && e.Detail.Chat != nil {
-		if err := validator.ValidateChat(e.Detail.Chat.Raw); err != nil {
-			return fmt.Errorf("chat validation failed: %w", err)
+	// Validate chat-related extensions if present
+	if e.Detail != nil {
+		if e.Detail.Chat != nil {
+			data, err := xml.Marshal(e.Detail.Chat)
+			if err != nil {
+				return fmt.Errorf("marshal chat: %w", err)
+			}
+			if err := validator.ValidateAgainstSchema("chat", data); err != nil {
+				return fmt.Errorf("chat validation failed: %w", err)
+			}
+		}
+		if e.Detail.ChatReceipt != nil {
+			data, err := xml.Marshal(e.Detail.ChatReceipt)
+			if err != nil {
+				return fmt.Errorf("marshal chatReceipt: %w", err)
+			}
+			if err := validator.ValidateAgainstSchema("chatReceipt", data); err != nil {
+				return fmt.Errorf("chatReceipt validation failed: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- validate chat and chatReceipt extensions against embedded XSDs
- verify schema enforcement in unit tests
- document validator usage in README

## Testing
- `go test ./...`