### PR TITLE
Add TAKCoT schema validation with tests

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -546,7 +546,8 @@ var doctypePattern = regexp.MustCompile(`(?i)<!\s*DOCTYPE`)
 
 // Contact represents contact information
 type Contact struct {
-	Callsign string `xml:"callsign,attr,omitempty"`
+	XMLName  xml.Name `xml:"contact"`
+	Callsign string   `xml:"callsign,attr,omitempty"`
 }
 
 // Detail contains additional information about an event
@@ -1160,6 +1161,22 @@ func (e *Event) ValidateAt(now time.Time) error {
 			data, _ := xml.Marshal(e.Detail.ChatReceipt)
 			if err := validator.ValidateAgainstSchema("chatReceipt", data); err != nil {
 				return fmt.Errorf("invalid chat receipt: %w", err)
+			}
+		}
+		if e.Detail.Contact != nil {
+			data, _ := xml.Marshal(e.Detail.Contact)
+			if err := validator.ValidateAgainstSchema("tak-details-contact", data); err != nil {
+				return fmt.Errorf("invalid contact: %w", err)
+			}
+		}
+		if e.Detail.Track != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-track", e.Detail.Track.Raw); err != nil {
+				return fmt.Errorf("invalid track: %w", err)
+			}
+		}
+		if e.Detail.Status != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-status", e.Detail.Status.Raw); err != nil {
+				return fmt.Errorf("invalid status: %w", err)
 			}
 		}
 	}

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -17,3 +17,49 @@ func TestValidateAgainstSchemaNonet(t *testing.T) {
 		t.Fatal("expected error for external entity")
 	}
 }
+
+func TestValidateAgainstTAKDetailSchemas(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+		good   []byte
+		bad    []byte
+	}{
+		{
+			name:   "contact",
+			schema: "tak-details-contact",
+			good:   []byte(`<contact callsign="A"/>`),
+			bad:    []byte(`<contact/>`),
+		},
+		{
+			name:   "track",
+			schema: "tak-details-track",
+			good:   []byte(`<track course="90" speed="10"/>`),
+			bad:    []byte(`<track speed="10"/>`),
+		},
+		{
+			name:   "status",
+			schema: "tak-details-status",
+			good:   []byte(`<status battery="80"/>`),
+			bad:    []byte(`<status battery="bad"/>`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validator.ValidateAgainstSchema(tt.schema, tt.good); err != nil {
+				t.Fatalf("valid %s rejected: %v", tt.name, err)
+			}
+			if err := validator.ValidateAgainstSchema(tt.schema, tt.bad); err == nil {
+				t.Fatalf("expected error for invalid %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestListAvailableSchemas(t *testing.T) {
+	schemas := validator.ListAvailableSchemas()
+	if len(schemas) == 0 {
+		t.Fatal("no schemas returned")
+	}
+}

--- a/validator/validator_bench_test.go
+++ b/validator/validator_bench_test.go
@@ -1,0 +1,27 @@
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/NERVsystems/cotlib/validator"
+)
+
+func BenchmarkValidateAgainstSchemaContact(b *testing.B) {
+	xml := []byte(`<contact callsign="A"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-contact", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkValidateAgainstSchemaTrack(b *testing.B) {
+	xml := []byte(`<track course="90" speed="10"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-track", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- support TAKCoT detail schema validation for Contact, Track and Status
- expand validator tests for TAKCoT schemas
- add benchmarks for schema validation
- test detail schema validation in `validation_test.go`

## Testing
- `go test ./...`
- `go test -bench . ./...`
