### PR TITLE
Add TAKCoT schema coverage

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -546,7 +546,8 @@ var doctypePattern = regexp.MustCompile(`(?i)<!\s*DOCTYPE`)
 
 // Contact represents contact information
 type Contact struct {
-	Callsign string `xml:"callsign,attr,omitempty"`
+	XMLName  xml.Name `xml:"contact"`
+	Callsign string   `xml:"callsign,attr,omitempty"`
 }
 
 // Detail contains additional information about an event
@@ -1160,6 +1161,72 @@ func (e *Event) ValidateAt(now time.Time) error {
 			data, _ := xml.Marshal(e.Detail.ChatReceipt)
 			if err := validator.ValidateAgainstSchema("chatReceipt", data); err != nil {
 				return fmt.Errorf("invalid chat receipt: %w", err)
+			}
+		}
+		if e.Detail.Contact != nil {
+			data, _ := xml.Marshal(e.Detail.Contact)
+			if err := validator.ValidateAgainstSchema("tak-details-contact", data); err != nil {
+				return fmt.Errorf("invalid contact: %w", err)
+			}
+		}
+		if e.Detail.Track != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-track", e.Detail.Track.Raw); err != nil {
+				return fmt.Errorf("invalid track: %w", err)
+			}
+		}
+		if e.Detail.Status != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-status", e.Detail.Status.Raw); err != nil {
+				return fmt.Errorf("invalid status: %w", err)
+			}
+		}
+		if e.Detail.Archive != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-archive", e.Detail.Archive.Raw); err != nil {
+				return fmt.Errorf("invalid archive: %w", err)
+			}
+		}
+		if e.Detail.Environment != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-environment", e.Detail.Environment.Raw); err != nil {
+				return fmt.Errorf("invalid environment: %w", err)
+			}
+		}
+		if e.Detail.FileShare != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-fileshare", e.Detail.FileShare.Raw); err != nil {
+				return fmt.Errorf("invalid fileshare: %w", err)
+			}
+		}
+		if e.Detail.PrecisionLocation != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-precisionlocation", e.Detail.PrecisionLocation.Raw); err != nil {
+				return fmt.Errorf("invalid precisionlocation: %w", err)
+			}
+		}
+		if e.Detail.Takv != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-takv", e.Detail.Takv.Raw); err != nil {
+				return fmt.Errorf("invalid takv: %w", err)
+			}
+		}
+		if e.Detail.Mission != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-mission", e.Detail.Mission.Raw); err != nil {
+				return fmt.Errorf("invalid mission: %w", err)
+			}
+		}
+		if e.Detail.Shape != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-shape", e.Detail.Shape.Raw); err != nil {
+				return fmt.Errorf("invalid shape: %w", err)
+			}
+		}
+		if e.Detail.ColorExtension != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-color", e.Detail.ColorExtension.Raw); err != nil {
+				return fmt.Errorf("invalid color: %w", err)
+			}
+		}
+		if e.Detail.UserIcon != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-usericon", e.Detail.UserIcon.Raw); err != nil {
+				return fmt.Errorf("invalid usericon: %w", err)
+			}
+		}
+		if e.Detail.Remarks != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-remarks", e.Detail.Remarks.Raw); err != nil {
+				return fmt.Errorf("invalid remarks: %w", err)
 			}
 		}
 	}

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -17,3 +17,85 @@ func TestValidateAgainstSchemaNonet(t *testing.T) {
 		t.Fatal("expected error for external entity")
 	}
 }
+
+func TestValidateAgainstTAKDetailSchemas(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+		good   []byte
+		bad    []byte
+	}{
+		{
+			name:   "contact",
+			schema: "tak-details-contact",
+			good:   []byte(`<contact callsign="A"/>`),
+			bad:    []byte(`<contact/>`),
+		},
+		{
+			name:   "track",
+			schema: "tak-details-track",
+			good:   []byte(`<track course="90" speed="10"/>`),
+			bad:    []byte(`<track speed="10"/>`),
+		},
+		{
+			name:   "status",
+			schema: "tak-details-status",
+			good:   []byte(`<status battery="80"/>`),
+			bad:    []byte(`<status battery="bad"/>`),
+		},
+		{
+			name:   "environment",
+			schema: "tak-details-environment",
+			good:   []byte(`<environment temperature="1" windDirection="2" windSpeed="3"/>`),
+			bad:    []byte(`<environment temperature="1" windDirection="2"/>`),
+		},
+		{
+			name:   "shape",
+			schema: "tak-details-shape",
+			good:   []byte(`<shape><polyline closed="false"><vertex lat="0" lon="0" hae="0"/></polyline></shape>`),
+			bad:    []byte(`<shape><polyline><vertex lat="0" lon="0"/></polyline></shape>`),
+		},
+		{
+			name:   "color",
+			schema: "tak-details-color",
+			good:   []byte(`<color argb="1"/>`),
+			bad:    []byte(`<color/>`),
+		},
+		{
+			name:   "usericon",
+			schema: "tak-details-usericon",
+			good:   []byte(`<usericon iconsetpath="foo"/>`),
+			bad:    []byte(`<usericon/>`),
+		},
+		{
+			name:   "mission",
+			schema: "tak-details-mission",
+			good:   []byte(`<mission name="op" tool="t" type="x"/>`),
+			bad:    []byte(`<mission name="op" tool="t"/>`),
+		},
+		{
+			name:   "attachment_list",
+			schema: "tak-details-attachment_list",
+			good:   []byte(`<attachment_list hashes="abc"/>`),
+			bad:    []byte(`<attachment_list/>`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validator.ValidateAgainstSchema(tt.schema, tt.good); err != nil {
+				t.Fatalf("valid %s rejected: %v", tt.name, err)
+			}
+			if err := validator.ValidateAgainstSchema(tt.schema, tt.bad); err == nil {
+				t.Fatalf("expected error for invalid %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestListAvailableSchemas(t *testing.T) {
+	schemas := validator.ListAvailableSchemas()
+	if len(schemas) == 0 {
+		t.Fatal("no schemas returned")
+	}
+}

--- a/validator/validator_bench_test.go
+++ b/validator/validator_bench_test.go
@@ -1,0 +1,37 @@
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/NERVsystems/cotlib/validator"
+)
+
+func BenchmarkValidateAgainstSchemaContact(b *testing.B) {
+	xml := []byte(`<contact callsign="A"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-contact", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkValidateAgainstSchemaTrack(b *testing.B) {
+	xml := []byte(`<track course="90" speed="10"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-track", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkValidateAgainstSchemaEnvironment(b *testing.B) {
+	xml := []byte(`<environment temperature="1" windDirection="2" windSpeed="3"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-environment", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- embed all TAKCoT XSD files and load them at runtime
- extend validator with CompileFile and schema loader
- validate additional TAKCoT detail extensions
- add comprehensive schema tests and benchmarks

## Testing
- `go test ./...`
- `go test -bench . ./...`
