### PR TITLE
Add novalidator build tag to schema validation

### DIFF
--- a/schema_validate.go
+++ b/schema_validate.go
@@ -1,3 +1,5 @@
+//go:build !novalidator
+
 package cotlib
 
 // ValidateAgainstSchema validates the given XML against the CoT schema.


### PR DESCRIPTION
## Summary
- exclude `schema_validate.go` when building with the `novalidator` tag by adding a build constraint

## Testing
- `go build -tags novalidator ./...`
- `go test -v ./...`
