### PR TITLE
Fix event pool release on validation failure

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -956,6 +956,7 @@ func NewEvent(uid, typ string, lat, lon, hae float64) (*Event, error) {
 		},
 	}
 	if err := evt.ValidateAt(now); err != nil {
+		ReleaseEvent(evt)
 		return nil, err
 	}
 	return evt, nil

--- a/event_pool_test.go
+++ b/event_pool_test.go
@@ -47,3 +47,21 @@ func TestUnmarshalXMLEventCtxLogsError(t *testing.T) {
 		t.Errorf("expected error log, got: %s", logOutput)
 	}
 }
+
+func TestNewEventPoolReuseOnValidationError(t *testing.T) {
+	pct := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(pct)
+
+	base := getEvent()
+	ReleaseEvent(base)
+
+	if _, err := NewEvent("test", "a-f-G", 95, 0, 0); err == nil {
+		t.Fatal("expected validation error")
+	}
+
+	e := getEvent()
+	if e != base {
+		t.Error("event was not returned to pool after validation failure")
+	}
+	ReleaseEvent(e)
+}


### PR DESCRIPTION
## Summary
- release pooled event when `NewEvent` validation fails
- add unit test to ensure events return to pool on validation errors

## Testing
- `go test -v ./...`