### PR TITLE
fix validator init error handling

### DIFF
--- a/validation_test.go
+++ b/validation_test.go
@@ -410,6 +410,7 @@ func TestAdditionalDetailExtensionsRoundTrip(t *testing.T) {
 }
 
 func TestChatSchemaValidation(t *testing.T) {
+	validator.ResetForTest()
 	valid := []byte(`<__chat sender="A" message="hi"/>`)
 	if err := validator.ValidateAgainstSchema("chat", valid); err != nil {
 		t.Fatalf("valid chat rejected: %v", err)

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestValidateAgainstSchemaNonet(t *testing.T) {
+	validator.ResetForTest()
 	good := []byte(`<__chat sender="Alice" message="hi"/>`)
 	if err := validator.ValidateAgainstSchema("chat", good); err != nil {
 		t.Fatalf("valid chat rejected: %v", err)
@@ -19,6 +20,7 @@ func TestValidateAgainstSchemaNonet(t *testing.T) {
 }
 
 func TestValidateAgainstTAKDetailSchemas(t *testing.T) {
+	validator.ResetForTest()
 	tests := []struct {
 		name   string
 		schema string
@@ -94,6 +96,7 @@ func TestValidateAgainstTAKDetailSchemas(t *testing.T) {
 }
 
 func TestListAvailableSchemas(t *testing.T) {
+	validator.ResetForTest()
 	schemas := validator.ListAvailableSchemas()
 	if len(schemas) == 0 {
 		t.Fatal("no schemas returned")

--- a/validator/test_helpers.go
+++ b/validator/test_helpers.go
@@ -1,0 +1,25 @@
+package validator
+
+import (
+	"os"
+	"sync"
+)
+
+// ResetForTest resets package state for testing.
+func ResetForTest() {
+	once = sync.Once{}
+	schemas = nil
+	initErr = nil
+	mkTemp = os.MkdirTemp
+	writeSchemasFn = writeSchemas
+}
+
+// SetMkTempForTest sets the MkdirTemp function for testing.
+func SetMkTempForTest(f func(string, string) (string, error)) {
+	mkTemp = f
+}
+
+// SetWriteSchemasForTest sets the schema writing function for testing.
+func SetWriteSchemasForTest(f func(string) error) {
+	writeSchemasFn = f
+}

--- a/validator/validator_error_test.go
+++ b/validator/validator_error_test.go
@@ -1,0 +1,54 @@
+package validator_test
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/NERVsystems/cotlib/validator"
+)
+
+func TestValidateAgainstSchemaInitErrors(t *testing.T) {
+	t.Run("mktemp", func(t *testing.T) {
+		validator.ResetForTest()
+		validator.SetMkTempForTest(func(string, string) (string, error) {
+			return "", errors.New("mktemp fail")
+		})
+		err := validator.ValidateAgainstSchema("chat", nil)
+		if err == nil || !strings.Contains(err.Error(), "mktemp fail") {
+			t.Fatalf("expected mktemp error, got %v", err)
+		}
+		if err2 := validator.ValidateAgainstSchema("chat", nil); err2 == nil || err2.Error() != err.Error() {
+			t.Fatalf("expected same error on subsequent call, got %v", err2)
+		}
+	})
+
+	t.Run("write", func(t *testing.T) {
+		validator.ResetForTest()
+		validator.SetWriteSchemasForTest(func(string) error {
+			return errors.New("write fail")
+		})
+		err := validator.ValidateAgainstSchema("chat", nil)
+		if err == nil || !strings.Contains(err.Error(), "write schemas") {
+			t.Fatalf("expected write error, got %v", err)
+		}
+	})
+}
+
+func TestInitSchemasRemovesTempDir(t *testing.T) {
+	validator.ResetForTest()
+	var dir string
+	validator.SetMkTempForTest(func(string, string) (string, error) {
+		var err error
+		dir, err = os.MkdirTemp("", "cotlib-test")
+		return dir, err
+	})
+
+	if err := validator.ValidateAgainstSchema("chat", []byte(`<__chat sender="A" message="hi"/>`)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("temp dir not removed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- clean up temp schema directory in `initSchemas`
- return initialization errors instead of panicking
- expose testing helpers and update tests
- add regression tests for error paths

## Testing
- `go test ./...`