### PR TITLE
Add more TAKCoT schemas

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,3 +1,39 @@
 - [ ] Tighten wildcard validation to reject embedded '*'
 - [ ] Use context-based logging throughout
 - [ ] Add tests for embedded wildcard rejection
+# Full Schema Coverage TODO
+- [ ] Embed and compile remaining detail schemas
+  - __chat.xsd
+  - __chatreceipt.xsd
+  - __geofence.xsd
+  - __group.xsd
+  - __serverdestination.xsd
+  - __video.xsd
+  - archive.xsd
+  - attachment_list.xsd
+  - chatgrp.xsd
+  - color.xsd
+  - environment.xsd
+  - fileshare.xsd
+  - fillColor.xsd
+  - height.xsd
+  - height_unit.xsd
+  - hierarchy.xsd
+  - labels_on.xsd
+  - link.xsd
+  - mission.xsd
+  - precisionlocation.xsd
+  - shape.xsd
+  - strokeColor.xsd
+  - strokeWeight.xsd
+  - takv.xsd
+  - uid.xsd
+  - usericon.xsd
+- [ ] Add validation hooks in Event.ValidateAt or during XML unmarshalling
+- [ ] Integrate remaining top-level schemas
+  - Drawing shape schemas (Circle, Free Form, Rectangle, Telestration)
+  - Geo Fence and Range & Bearing schemas
+  - Route schemas (Route.xsd, tak-route.xsd)
+  - Marker schemas (2525, Icon Set, Spot)
+- [ ] Develop comprehensive tests for all new detail extensions
+- [ ] Expand benchmarks for representative schemas

--- a/cotlib.go
+++ b/cotlib.go
@@ -546,7 +546,8 @@ var doctypePattern = regexp.MustCompile(`(?i)<!\s*DOCTYPE`)
 
 // Contact represents contact information
 type Contact struct {
-	Callsign string `xml:"callsign,attr,omitempty"`
+	XMLName  xml.Name `xml:"contact"`
+	Callsign string   `xml:"callsign,attr,omitempty"`
 }
 
 // Detail contains additional information about an event
@@ -1160,6 +1161,57 @@ func (e *Event) ValidateAt(now time.Time) error {
 			data, _ := xml.Marshal(e.Detail.ChatReceipt)
 			if err := validator.ValidateAgainstSchema("chatReceipt", data); err != nil {
 				return fmt.Errorf("invalid chat receipt: %w", err)
+			}
+		}
+		if e.Detail.Contact != nil {
+			data, _ := xml.Marshal(e.Detail.Contact)
+			if err := validator.ValidateAgainstSchema("tak-details-contact", data); err != nil {
+				return fmt.Errorf("invalid contact: %w", err)
+			}
+		}
+		if e.Detail.Track != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-track", e.Detail.Track.Raw); err != nil {
+				return fmt.Errorf("invalid track: %w", err)
+			}
+		}
+		if e.Detail.Status != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-status", e.Detail.Status.Raw); err != nil {
+				return fmt.Errorf("invalid status: %w", err)
+			}
+		}
+		if e.Detail.Environment != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-environment", e.Detail.Environment.Raw); err != nil {
+				return fmt.Errorf("invalid environment: %w", err)
+			}
+		}
+		if e.Detail.FileShare != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-fileshare", e.Detail.FileShare.Raw); err != nil {
+				return fmt.Errorf("invalid fileshare: %w", err)
+			}
+		}
+		if e.Detail.PrecisionLocation != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-precisionlocation", e.Detail.PrecisionLocation.Raw); err != nil {
+				return fmt.Errorf("invalid precisionlocation: %w", err)
+			}
+		}
+		if e.Detail.Takv != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-takv", e.Detail.Takv.Raw); err != nil {
+				return fmt.Errorf("invalid takv: %w", err)
+			}
+		}
+		if e.Detail.Mission != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-mission", e.Detail.Mission.Raw); err != nil {
+				return fmt.Errorf("invalid mission: %w", err)
+			}
+		}
+		if e.Detail.Shape != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-shape", e.Detail.Shape.Raw); err != nil {
+				return fmt.Errorf("invalid shape: %w", err)
+			}
+		}
+		if e.Detail.ColorExtension != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-color", e.Detail.ColorExtension.Raw); err != nil {
+				return fmt.Errorf("invalid color: %w", err)
 			}
 		}
 	}

--- a/validation_test.go
+++ b/validation_test.go
@@ -350,14 +350,14 @@ func TestAdditionalDetailExtensionsRoundTrip(t *testing.T) {
 
 	archiveXML := []byte(`<archive id="a"><item></item></archive>`)
 	attachmentXML := []byte(`<attachmentList><file id="f1"></file></attachmentList>`)
-	envXML := []byte(`<environment state="on"></environment>`)
-	fileShareXML := []byte(`<fileshare url="http://example"></fileshare>`)
-	precisionXML := []byte(`<precisionlocation acc="5"></precisionlocation>`)
-	takvXML := []byte(`<takv version="4.0" platform="android"></takv>`)
-	trackXML := []byte(`<track course="90"></track>`)
-	missionXML := []byte(`<mission name="op"><task></task></mission>`)
+	envXML := []byte(`<environment temperature="20" windDirection="10" windSpeed="5"></environment>`)
+	fileShareXML := []byte(`<fileshare filename="f" name="n" senderCallsign="A" senderUid="U" senderUrl="http://x" sha256="h" sizeInBytes="1"></fileshare>`)
+	precisionXML := []byte(`<precisionlocation altsrc="GPS"></precisionlocation>`)
+	takvXML := []byte(`<takv platform="Android" version="1"></takv>`)
+	trackXML := []byte(`<track course="90" speed="10"></track>`)
+	missionXML := []byte(`<mission name="op" tool="t" type="x"></mission>`)
 	statusXML := []byte(`<status battery="80"></status>`)
-	shapeXML := []byte(`<shape><point lat="1" lon="2"></point></shape>`)
+	shapeXML := []byte(`<shape><polyline closed="true"><vertex hae="0" lat="1" lon="1"></vertex></polyline></shape>`)
 
 	evt.Detail = &cotlib.Detail{
 		Archive:           &cotlib.Archive{Raw: archiveXML},
@@ -457,4 +457,187 @@ func TestUnmarshalInvalidChatExtensions(t *testing.T) {
 			t.Error("expected error for invalid chatReceipt")
 		}
 	})
+}
+
+func TestTAKDetailSchemaValidation(t *testing.T) {
+	t.Run("contact", func(t *testing.T) {
+		evt, err := cotlib.NewEvent("C1", "t-x-d", 1, 1, 0)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		evt.Detail = &cotlib.Detail{
+			Contact: &cotlib.Contact{Callsign: "A"},
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("valid contact rejected: %v", err)
+		}
+		evt.Detail.Contact.Callsign = ""
+		if err := evt.Validate(); err == nil {
+			t.Fatal("expected error for missing callsign")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
+	t.Run("track", func(t *testing.T) {
+		evt, err := cotlib.NewEvent("T1", "t-x-t", 1, 1, 0)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		evt.Detail = &cotlib.Detail{
+			Track: &cotlib.Track{Raw: []byte(`<track course="90" speed="10"/>`)},
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("valid track rejected: %v", err)
+		}
+		evt.Detail.Track.Raw = []byte(`<track speed="10"/>`)
+		if err := evt.Validate(); err == nil {
+			t.Fatal("expected error for invalid track")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
+	t.Run("status", func(t *testing.T) {
+		evt, err := cotlib.NewEvent("S1", "a-f-G", 1, 1, 0)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		evt.Detail = &cotlib.Detail{
+			Status: &cotlib.Status{Raw: []byte(`<status battery="80"/>`)},
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("valid status rejected: %v", err)
+		}
+		evt.Detail.Status.Raw = []byte(`<status battery="bad"/>`)
+		if err := evt.Validate(); err == nil {
+			t.Fatal("expected error for invalid status")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
+	t.Run("environment", func(t *testing.T) {
+		evt, err := cotlib.NewEvent("E1", "a-f-G", 1, 1, 0)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		evt.Detail = &cotlib.Detail{
+			Environment: &cotlib.Environment{Raw: []byte(`<environment temperature="20" windDirection="10" windSpeed="5"/>`)},
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("valid environment rejected: %v", err)
+		}
+		evt.Detail.Environment.Raw = []byte(`<environment temperature="20" windSpeed="5"/>`)
+		if err := evt.Validate(); err == nil {
+			t.Fatal("expected error for invalid environment")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
+	t.Run("fileshare", func(t *testing.T) {
+		evt, err := cotlib.NewEvent("F1", "a-f-G", 1, 1, 0)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		evt.Detail = &cotlib.Detail{
+			FileShare: &cotlib.FileShare{Raw: []byte(`<fileshare filename="f" name="n" senderCallsign="A" senderUid="U" senderUrl="http://x" sha256="h" sizeInBytes="1"/>`)},
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("valid fileshare rejected: %v", err)
+		}
+		evt.Detail.FileShare.Raw = []byte(`<fileshare filename="f" name="n" senderCallsign="A" senderUid="U" senderUrl="http://x" sha256="h"/>`)
+		if err := evt.Validate(); err == nil {
+			t.Fatal("expected error for invalid fileshare")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
+	t.Run("precisionlocation", func(t *testing.T) {
+		evt, err := cotlib.NewEvent("P1", "a-f-G", 1, 1, 0)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		evt.Detail = &cotlib.Detail{
+			PrecisionLocation: &cotlib.PrecisionLocation{Raw: []byte(`<precisionlocation altsrc="GPS"/>`)},
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("valid precisionlocation rejected: %v", err)
+		}
+		evt.Detail.PrecisionLocation.Raw = []byte(`<precisionlocation/>`)
+		if err := evt.Validate(); err == nil {
+			t.Fatal("expected error for invalid precisionlocation")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
+	t.Run("takv", func(t *testing.T) {
+		evt, err := cotlib.NewEvent("TV1", "a-f-G", 1, 1, 0)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		evt.Detail = &cotlib.Detail{
+			Takv: &cotlib.Takv{Raw: []byte(`<takv platform="Android" version="1"/>`)},
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("valid takv rejected: %v", err)
+		}
+		evt.Detail.Takv.Raw = []byte(`<takv platform="Android"/>`)
+		if err := evt.Validate(); err == nil {
+			t.Fatal("expected error for invalid takv")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
+	t.Run("mission", func(t *testing.T) {
+		evt, err := cotlib.NewEvent("M1", "a-f-G", 1, 1, 0)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		evt.Detail = &cotlib.Detail{
+			Mission: &cotlib.Mission{Raw: []byte(`<mission name="m" tool="t" type="x"/>`)},
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("valid mission rejected: %v", err)
+		}
+		evt.Detail.Mission.Raw = []byte(`<mission tool="t" type="x"/>`)
+		if err := evt.Validate(); err == nil {
+			t.Fatal("expected error for invalid mission")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
+	t.Run("shape", func(t *testing.T) {
+		evt, err := cotlib.NewEvent("SH1", "a-f-G", 1, 1, 0)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		evt.Detail = &cotlib.Detail{
+			Shape: &cotlib.Shape{Raw: []byte(`<shape><polyline closed="true"><vertex hae="0" lat="1" lon="1"/></polyline></shape>`)},
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("valid shape rejected: %v", err)
+		}
+		evt.Detail.Shape.Raw = []byte(`<shape><polyline closed="true"></polyline></shape>`)
+		if err := evt.Validate(); err == nil {
+			t.Fatal("expected error for invalid shape")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
+	t.Run("color", func(t *testing.T) {
+		evt, err := cotlib.NewEvent("C2", "a-f-G", 1, 1, 0)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		evt.Detail = &cotlib.Detail{
+			ColorExtension: &cotlib.ColorExtension{Raw: []byte(`<color argb="1"/>`)},
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("valid color rejected: %v", err)
+		}
+		evt.Detail.ColorExtension.Raw = []byte(`<color/>`)
+		if err := evt.Validate(); err == nil {
+			t.Fatal("expected error for invalid color")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
 }

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -17,3 +17,91 @@ func TestValidateAgainstSchemaNonet(t *testing.T) {
 		t.Fatal("expected error for external entity")
 	}
 }
+
+func TestValidateAgainstTAKDetailSchemas(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+		good   []byte
+		bad    []byte
+	}{
+		{
+			name:   "contact",
+			schema: "tak-details-contact",
+			good:   []byte(`<contact callsign="A"/>`),
+			bad:    []byte(`<contact/>`),
+		},
+		{
+			name:   "track",
+			schema: "tak-details-track",
+			good:   []byte(`<track course="90" speed="10"/>`),
+			bad:    []byte(`<track speed="10"/>`),
+		},
+		{
+			name:   "status",
+			schema: "tak-details-status",
+			good:   []byte(`<status battery="80"/>`),
+			bad:    []byte(`<status battery="bad"/>`),
+		},
+		{
+			name:   "environment",
+			schema: "tak-details-environment",
+			good:   []byte(`<environment temperature="20" windDirection="10" windSpeed="5"/>`),
+			bad:    []byte(`<environment temperature="20" windSpeed="5"/>`),
+		},
+		{
+			name:   "fileshare",
+			schema: "tak-details-fileshare",
+			good:   []byte(`<fileshare filename="f" name="n" senderCallsign="A" senderUid="U" senderUrl="http://x" sha256="h" sizeInBytes="1"/>`),
+			bad:    []byte(`<fileshare filename="f" name="n" senderCallsign="A" senderUid="U" senderUrl="http://x" sha256="h"/>`),
+		},
+		{
+			name:   "precisionlocation",
+			schema: "tak-details-precisionlocation",
+			good:   []byte(`<precisionlocation altsrc="GPS"/>`),
+			bad:    []byte(`<precisionlocation/>`),
+		},
+		{
+			name:   "takv",
+			schema: "tak-details-takv",
+			good:   []byte(`<takv platform="Android" version="1"/>`),
+			bad:    []byte(`<takv platform="Android"/>`),
+		},
+		{
+			name:   "mission",
+			schema: "tak-details-mission",
+			good:   []byte(`<mission name="m" tool="t" type="x"/>`),
+			bad:    []byte(`<mission tool="t" type="x"/>`),
+		},
+		{
+			name:   "shape",
+			schema: "tak-details-shape",
+			good:   []byte(`<shape><polyline closed="true"><vertex hae="0" lat="1" lon="1"/></polyline></shape>`),
+			bad:    []byte(`<shape><polyline closed="true"></polyline></shape>`),
+		},
+		{
+			name:   "color",
+			schema: "tak-details-color",
+			good:   []byte(`<color argb="1"/>`),
+			bad:    []byte(`<color/>`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validator.ValidateAgainstSchema(tt.schema, tt.good); err != nil {
+				t.Fatalf("valid %s rejected: %v", tt.name, err)
+			}
+			if err := validator.ValidateAgainstSchema(tt.schema, tt.bad); err == nil {
+				t.Fatalf("expected error for invalid %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestListAvailableSchemas(t *testing.T) {
+	schemas := validator.ListAvailableSchemas()
+	if len(schemas) == 0 {
+		t.Fatal("no schemas returned")
+	}
+}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -29,6 +29,27 @@ var takDetailsTrackXSD []byte
 //go:embed schemas/details/remarks.xsd
 var takDetailsRemarksXSD []byte
 
+//go:embed schemas/details/environment.xsd
+var takDetailsEnvironmentXSD []byte
+
+//go:embed schemas/details/fileshare.xsd
+var takDetailsFileshareXSD []byte
+
+//go:embed schemas/details/precisionlocation.xsd
+var takDetailsPrecisionLocationXSD []byte
+
+//go:embed schemas/details/takv.xsd
+var takDetailsTakvXSD []byte
+
+//go:embed schemas/details/mission.xsd
+var takDetailsMissionXSD []byte
+
+//go:embed schemas/details/shape.xsd
+var takDetailsShapeXSD []byte
+
+//go:embed schemas/details/color.xsd
+var takDetailsColorXSD []byte
+
 var (
 	schemas map[string]*Schema
 	once    sync.Once
@@ -80,6 +101,48 @@ func initSchemas() {
 		panic(fmt.Errorf("compile TAK details remarks schema: %w", err))
 	}
 	schemas["tak-details-remarks"] = takDetailsRemarks
+
+	takDetailsEnvironment, err := Compile(takDetailsEnvironmentXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile TAK details environment schema: %w", err))
+	}
+	schemas["tak-details-environment"] = takDetailsEnvironment
+
+	takDetailsFileshare, err := Compile(takDetailsFileshareXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile TAK details fileshare schema: %w", err))
+	}
+	schemas["tak-details-fileshare"] = takDetailsFileshare
+
+	takDetailsPrecisionLocation, err := Compile(takDetailsPrecisionLocationXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile TAK details precisionlocation schema: %w", err))
+	}
+	schemas["tak-details-precisionlocation"] = takDetailsPrecisionLocation
+
+	takDetailsTakv, err := Compile(takDetailsTakvXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile TAK details takv schema: %w", err))
+	}
+	schemas["tak-details-takv"] = takDetailsTakv
+
+	takDetailsMission, err := Compile(takDetailsMissionXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile TAK details mission schema: %w", err))
+	}
+	schemas["tak-details-mission"] = takDetailsMission
+
+	takDetailsShape, err := Compile(takDetailsShapeXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile TAK details shape schema: %w", err))
+	}
+	schemas["tak-details-shape"] = takDetailsShape
+
+	takDetailsColor, err := Compile(takDetailsColorXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile TAK details color schema: %w", err))
+	}
+	schemas["tak-details-color"] = takDetailsColor
 }
 
 // ValidateAgainstSchema validates XML against a named schema.

--- a/validator/validator_bench_test.go
+++ b/validator/validator_bench_test.go
@@ -1,0 +1,37 @@
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/NERVsystems/cotlib/validator"
+)
+
+func BenchmarkValidateAgainstSchemaContact(b *testing.B) {
+	xml := []byte(`<contact callsign="A"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-contact", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkValidateAgainstSchemaTrack(b *testing.B) {
+	xml := []byte(`<track course="90" speed="10"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-track", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkValidateAgainstSchemaEnvironment(b *testing.B) {
+	xml := []byte(`<environment temperature="20" windDirection="10" windSpeed="5"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-environment", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- document remaining schema work in TASKS.md
- embed more TAKCoT detail schemas
- validate new detail extensions in `Event.ValidateAt`
- extend schema tests and benchmarks
- add test coverage for new schemas

## Testing
- `go test ./...`
- `go test -bench . ./...`
