### PR TITLE
Add invalid wildcard test cases

### DIFF
--- a/test/validation/validation_test.go
+++ b/test/validation/validation_test.go
@@ -278,13 +278,34 @@ func TestWildcardPatterns(t *testing.T) {
 			pattern: "a-f-G*X",
 			wantErr: true,
 		},
+		{
+			name:    "suffix after wildcard",
+			pattern: "a-*X",
+			wantErr: true,
+		},
+		{
+			name:    "mid wildcard suffix",
+			pattern: "a-f-G*-Z",
+			wantErr: true,
+		},
+		{
+			name:    "leading wildcard",
+			pattern: "*-a-f",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := cotlib.ValidateType(tt.pattern)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateType(%q) error = %v, want error = %v", tt.pattern, err, tt.wantErr)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ValidateType(%q) expected error", tt.pattern)
+				} else if !errors.Is(err, cotlib.ErrInvalidType) {
+					t.Errorf("ValidateType(%q) unexpected error = %v", tt.pattern, err)
+				}
+			} else if err != nil {
+				t.Errorf("ValidateType(%q) unexpected error = %v", tt.pattern, err)
 			}
 		})
 	}

--- a/validation_test.go
+++ b/validation_test.go
@@ -25,13 +25,24 @@ func TestWildcardPatterns(t *testing.T) {
 		{"multiple wildcard segments", "a-f-G-*-*", false},
 		{"double asterisk segment", "a-f-G**", false},
 		{"multi-embedded asterisks", "a*f*G", false},
+		{"suffix after wildcard", "a-*X", false},
+		{"mid wildcard suffix", "a-f-G*-Z", false},
+		{"leading wildcard", "*-a-f", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := cotlib.ValidateType(tt.pattern)
-			if (err == nil) != tt.expected {
-				t.Errorf("ValidateType(%q) error = %v, want error = %v", tt.pattern, err, !tt.expected)
+			if tt.expected {
+				if err != nil {
+					t.Errorf("ValidateType(%q) unexpected error = %v", tt.pattern, err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("ValidateType(%q) expected error", tt.pattern)
+				} else if !errors.Is(err, cotlib.ErrInvalidType) {
+					t.Errorf("ValidateType(%q) unexpected error = %v", tt.pattern, err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- extend wildcard tests to cover invalid patterns
- verify errors wrap `ErrInvalidType`

## Testing
- `go test ./... | tail -n 20`