### PR TITLE
Use context-based logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ func main() {
 </event>`
 
     // Parse XML into CoT event
-    event, err := cotlib.UnmarshalXMLEvent([]byte(xmlData))
+    event, err := cotlib.UnmarshalXMLEvent(context.Background(), []byte(xmlData))
     if err != nil {
         fmt.Printf("Error parsing XML: %v\n", err)
         return
@@ -182,7 +182,7 @@ xmlData := `<?xml version="1.0"?>
   </detail>
 </event>`
 
-evt, _ := cotlib.UnmarshalXMLEvent([]byte(xmlData))
+evt, _ := cotlib.UnmarshalXMLEvent(context.Background(), []byte(xmlData))
 out, _ := evt.ToXML()
 fmt.Println(string(out)) // prints the same XML
 ```
@@ -563,7 +563,7 @@ log.Info("logger ready")
 allocations. When you are done with an event, return it to the pool:
 
 ```go
-evt, _ := cotlib.UnmarshalXMLEvent(data)
+evt, _ := cotlib.UnmarshalXMLEvent(context.Background(), data)
 defer cotlib.ReleaseEvent(evt)
 ```
 ## Build Tags

--- a/cotlib_bench_test.go
+++ b/cotlib_bench_test.go
@@ -2,6 +2,7 @@ package cotlib
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -39,10 +40,11 @@ func BenchmarkUnmarshalXMLEvent(b *testing.B) {
 	if err != nil {
 		b.Fatalf("ToXML error: %v", err)
 	}
+	ctx := context.Background()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := UnmarshalXMLEvent(xmlData); err != nil {
+		if _, err := UnmarshalXMLEvent(ctx, xmlData); err != nil {
 			b.Fatalf("UnmarshalXMLEvent error: %v", err)
 		}
 	}

--- a/cottypes/catalog_bench_test.go
+++ b/cottypes/catalog_bench_test.go
@@ -1,11 +1,15 @@
 package cottypes
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func BenchmarkCatalogGetType(b *testing.B) {
 	cat := GetCatalog()
+	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
-		if _, err := cat.GetType("a-f-G-E-X-N"); err != nil {
+		if _, err := cat.GetType(ctx, "a-f-G-E-X-N"); err != nil {
 			b.Fatalf("GetType error: %v", err)
 		}
 	}
@@ -13,8 +17,9 @@ func BenchmarkCatalogGetType(b *testing.B) {
 
 func BenchmarkCatalogFindByFullName(b *testing.B) {
 	cat := GetCatalog()
+	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
-		res := cat.FindByFullName("Nbc Equipment")
+		res := cat.FindByFullName(ctx, "Nbc Equipment")
 		if len(res) == 0 {
 			b.Fatal("no results")
 		}
@@ -23,8 +28,9 @@ func BenchmarkCatalogFindByFullName(b *testing.B) {
 
 func BenchmarkCatalogFindByDescription(b *testing.B) {
 	cat := GetCatalog()
+	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
-		res := cat.FindByDescription("NBC EQUIPMENT")
+		res := cat.FindByDescription(ctx, "NBC EQUIPMENT")
 		if len(res) == 0 {
 			b.Fatal("no results")
 		}

--- a/cottypes/cottypes_test.go
+++ b/cottypes/cottypes_test.go
@@ -1,11 +1,13 @@
 package cottypes
 
 import (
+	"context"
 	"testing"
 )
 
 // TestTypeValidation tests the GetType function for various valid and invalid CoT types.
 func TestTypeValidation(t *testing.T) {
+	ctx := context.Background()
 	tests := []struct {
 		name    string
 		typ     string
@@ -40,7 +42,7 @@ func TestTypeValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GetCatalog().GetType(tt.typ)
+			_, err := GetCatalog().GetType(ctx, tt.typ)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetType() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -50,6 +52,7 @@ func TestTypeValidation(t *testing.T) {
 
 // TestFindTypes tests the Find function for various query patterns.
 func TestFindTypes(t *testing.T) {
+	ctx := context.Background()
 	tests := []struct {
 		name     string
 		query    string
@@ -78,7 +81,7 @@ func TestFindTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matches := GetCatalog().Find(tt.query)
+			matches := GetCatalog().Find(ctx, tt.query)
 			if len(matches) != tt.wantLen {
 				t.Errorf("Find() returned %d matches, want %d", len(matches), tt.wantLen)
 			}

--- a/cottypes/types_embed.go
+++ b/cottypes/types_embed.go
@@ -26,7 +26,8 @@ func SetLogger(l *slog.Logger) {
 func GetCatalog() *Catalog {
 	var initErr error
 	catalogOnce.Do(func() {
-		catalog = NewCatalog(logger)
+		catalog = NewCatalog()
+		ctx := ctxlog.WithLogger(context.Background(), logger)
 
 		// Validate expanded types
 		if len(expandedTypes) == 0 {
@@ -46,7 +47,7 @@ func GetCatalog() *Catalog {
 				return
 			}
 
-			if err := catalog.Upsert(t.Name, Type{
+			if err := catalog.Upsert(ctx, t.Name, Type{
 				Name:        t.Name,
 				FullName:    t.FullName,
 				Description: t.Description,
@@ -78,7 +79,7 @@ func GetCatalog() *Catalog {
 		criticalTypes := []string{"a-f-G-E-X-N", "a-h-G-E-X-N", "a-n-G-E-X-N", "a-u-G-E-X-N"}
 		var missingCritical []string
 		for _, typ := range criticalTypes {
-			if _, err := catalog.GetType(typ); err != nil {
+			if _, err := catalog.GetType(ctx, typ); err != nil {
 				missingCritical = append(missingCritical, typ)
 			}
 		}
@@ -132,7 +133,7 @@ func RegisterXML(ctx context.Context, data []byte) error {
 				affiliations := []string{"f", "h", "n", "u"} // f=friendly, h=hostile, n=neutral, u=unknown
 				for _, aff := range affiliations {
 					expandedType := "a-" + aff + "-" + parts[1]
-					if err := cat.Upsert(expandedType, Type{
+					if err := cat.Upsert(ctx, expandedType, Type{
 						Name:        expandedType,
 						FullName:    t.Full,
 						Description: t.Desc,
@@ -149,7 +150,7 @@ func RegisterXML(ctx context.Context, data []byte) error {
 				successCount += expandedCount
 			}
 		} else {
-			if err := cat.Upsert(cotType, Type{
+			if err := cat.Upsert(ctx, cotType, Type{
 				Name:        cotType,
 				FullName:    t.Full,
 				Description: t.Desc,

--- a/event_pool_test.go
+++ b/event_pool_test.go
@@ -20,7 +20,7 @@ func TestEventPoolReuseOnInvalidXML(t *testing.T) {
 
 	// Parse invalid XML to trigger error after pool allocation
 	invalid := []byte("<event><bad></event>")
-	if _, err := UnmarshalXMLEvent(invalid); err == nil {
+	if _, err := UnmarshalXMLEvent(context.Background(), invalid); err == nil {
 		t.Fatal("expected error from invalid XML")
 	}
 

--- a/examples/chat_extension_example.go
+++ b/examples/chat_extension_example.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,6 +14,7 @@ import (
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	cotlib.SetLogger(logger)
+	ctx := cotlib.WithLogger(context.Background(), logger)
 
 	xmlInput := `<?xml version="1.0" encoding="UTF-8"?>
 <event version="2.0" uid="CHAT-1" type="t-x-c" time="2023-05-15T18:30:22Z" start="2023-05-15T18:30:22Z" stale="2023-05-15T18:30:32Z">
@@ -23,7 +25,7 @@ func main() {
   </detail>
 </event>`
 
-	evt, err := cotlib.UnmarshalXMLEvent([]byte(xmlInput))
+	evt, err := cotlib.UnmarshalXMLEvent(ctx, []byte(xmlInput))
 	if err != nil {
 		logger.Error("failed to parse event", "error", err)
 		return

--- a/examples/stroke_usericon_example.go
+++ b/examples/stroke_usericon_example.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,6 +14,7 @@ import (
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	cotlib.SetLogger(logger)
+	ctx := cotlib.WithLogger(context.Background(), logger)
 
 	evt, err := cotlib.NewEvent("EXAMPLE-1", "u-d-p", 34.0, -117.0, 0)
 	if err != nil {
@@ -29,7 +31,7 @@ func main() {
 	}
 	fmt.Println(string(xmlData))
 
-	out, err := cotlib.UnmarshalXMLEvent(xmlData)
+	out, err := cotlib.UnmarshalXMLEvent(ctx, xmlData)
 	if err != nil {
 		logger.Error("unmarshal", "err", err)
 		return

--- a/examples_test.go
+++ b/examples_test.go
@@ -2,6 +2,7 @@ package cotlib_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sort"
 
@@ -228,7 +229,7 @@ func Example_roundTripStrokeColorUsericon() {
 	xmlData, _ := evt.ToXML()
 	cotlib.ReleaseEvent(evt)
 
-	out, _ := cotlib.UnmarshalXMLEvent(xmlData)
+	out, _ := cotlib.UnmarshalXMLEvent(context.Background(), xmlData)
 	fmt.Printf("strokeColor: %s\n", out.StrokeColor)
 	fmt.Printf("usericon: %s\n", out.UserIcon)
 	outXML, _ := out.ToXML()

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -1,6 +1,9 @@
 package cotlib
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestUnmarshalXMLEventRoundTrip(t *testing.T) {
 	orig, err := NewEvent("RT1", "a-f-G", 10.0, 20.0, 0)
@@ -13,7 +16,7 @@ func TestUnmarshalXMLEventRoundTrip(t *testing.T) {
 	}
 	ReleaseEvent(orig)
 
-	evt, err := UnmarshalXMLEvent(xmlData)
+	evt, err := UnmarshalXMLEvent(context.Background(), xmlData)
 	if err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}

--- a/test/validation/validation_test.go
+++ b/test/validation/validation_test.go
@@ -79,7 +79,7 @@ func TestValidationBaseline(t *testing.T) {
   <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;">
 ]>
 <event></event>`)
-		_, err := cotlib.UnmarshalXMLEvent(xmlData)
+		_, err := cotlib.UnmarshalXMLEvent(context.Background(), xmlData)
 		if !errors.Is(err, cotlib.ErrInvalidInput) {
 			t.Error("Expected DOCTYPE to be rejected")
 		}
@@ -93,7 +93,7 @@ func TestValidationBaseline(t *testing.T) {
 			`<?xml version="1.0"?><!   DOCTYPE foo><event></event>`,
 		}
 		for _, xmlStr := range cases {
-			_, err := cotlib.UnmarshalXMLEvent([]byte(xmlStr))
+			_, err := cotlib.UnmarshalXMLEvent(context.Background(), []byte(xmlStr))
 			if !errors.Is(err, cotlib.ErrInvalidInput) {
 				t.Errorf("Expected DOCTYPE to be rejected for %q", xmlStr)
 			}
@@ -129,7 +129,7 @@ func TestValidationBaseline(t *testing.T) {
     </nested1>
   </detail>
 </event>`)
-		_, err := cotlib.UnmarshalXMLEvent(xmlData)
+		_, err := cotlib.UnmarshalXMLEvent(context.Background(), xmlData)
 		if err == nil {
 			t.Error("Expected depth limit error")
 		}
@@ -209,7 +209,7 @@ func TestValidationBaseline(t *testing.T) {
 		xmlData := []byte(`<?xml version="1.0"?>
 <event xmlns="` + strings.Repeat("x", 1025) + `">
 </event>`)
-		_, err := cotlib.UnmarshalXMLEvent(xmlData)
+		_, err := cotlib.UnmarshalXMLEvent(context.Background(), xmlData)
 		if err == nil {
 			t.Error("Expected namespace length error")
 		}
@@ -218,7 +218,7 @@ func TestValidationBaseline(t *testing.T) {
 	t.Run("max_xml_size", func(t *testing.T) {
 		big := strings.Repeat("a", (2<<20)+1)
 		xmlData := []byte("<event>" + big + "</event>")
-		_, err := cotlib.UnmarshalXMLEvent(xmlData)
+		_, err := cotlib.UnmarshalXMLEvent(context.Background(), xmlData)
 		if !errors.Is(err, cotlib.ErrInvalidInput) {
 			t.Error("Expected size limit error")
 		}
@@ -227,7 +227,7 @@ func TestValidationBaseline(t *testing.T) {
 	t.Run("token_length_limit", func(t *testing.T) {
 		name := strings.Repeat("x", 1025)
 		xmlData := []byte("<event><" + name + "/></event>")
-		_, err := cotlib.UnmarshalXMLEvent(xmlData)
+		_, err := cotlib.UnmarshalXMLEvent(context.Background(), xmlData)
 		if !errors.Is(err, cotlib.ErrInvalidInput) {
 			t.Error("Expected token length error")
 		}
@@ -240,7 +240,7 @@ func TestValidationBaseline(t *testing.T) {
 			b.WriteString("<a></a>")
 		}
 		b.WriteString("</event>")
-		_, err := cotlib.UnmarshalXMLEvent([]byte(b.String()))
+		_, err := cotlib.UnmarshalXMLEvent(context.Background(), []byte(b.String()))
 		if !errors.Is(err, cotlib.ErrInvalidInput) {
 			t.Error("Expected element count error")
 		}

--- a/validation_test.go
+++ b/validation_test.go
@@ -2,6 +2,7 @@ package cotlib_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -341,7 +342,7 @@ func TestDetailExtensionsRoundTrip(t *testing.T) {
 	}
 	cotlib.ReleaseEvent(evt)
 
-	out, err := cotlib.UnmarshalXMLEvent(xmlData)
+	out, err := cotlib.UnmarshalXMLEvent(context.Background(), xmlData)
 	if err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -386,7 +387,7 @@ func TestAdditionalDetailExtensionsRoundTrip(t *testing.T) {
 	}
 	cotlib.ReleaseEvent(evt)
 
-	out, err := cotlib.UnmarshalXMLEvent(xmlData)
+	out, err := cotlib.UnmarshalXMLEvent(context.Background(), xmlData)
 	if err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -452,7 +453,7 @@ func TestUnmarshalInvalidChatExtensions(t *testing.T) {
 			now.Add(10*time.Second).Format(cotlib.CotTimeFormat),
 			`<__chat unknown="x"/>`,
 		)
-		if _, err := cotlib.UnmarshalXMLEvent([]byte(xmlData)); err == nil {
+		if _, err := cotlib.UnmarshalXMLEvent(context.Background(), []byte(xmlData)); err == nil {
 			t.Error("expected error for invalid chat")
 		}
 	})
@@ -463,7 +464,7 @@ func TestUnmarshalInvalidChatExtensions(t *testing.T) {
 			now.Add(10*time.Second).Format(cotlib.CotTimeFormat),
 			`<__chatReceipt/>`,
 		)
-		if _, err := cotlib.UnmarshalXMLEvent([]byte(xmlData)); err == nil {
+		if _, err := cotlib.UnmarshalXMLEvent(context.Background(), []byte(xmlData)); err == nil {
 			t.Error("expected error for invalid chatReceipt")
 		}
 	})


### PR DESCRIPTION
## Summary
- use context in catalog methods and UnmarshalXMLEvent
- inject logger via context in examples and tests
- update helper functions to pass context
- adjust README for new API

## Testing
- `go vet ./...`
- `go test ./...`