### PR TITLE
Integrate additional CoT detail schemas

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -3,10 +3,10 @@
 - [x] Add tests for embedded wildcard rejection
 # Full Schema Coverage TODO
 <!-- Remaining detail schemas have been embedded and compiled -->
-- [ ] Add validation hooks in Event.ValidateAt or during XML unmarshalling
+- [x] Add validation hooks in Event.ValidateAt or during XML unmarshalling
 - [ ] Integrate remaining top-level schemas
   - Drawing shape schemas (Circle, Free Form, Rectangle, Telestration)
-  - Geo Fence and Range & Bearing schemas
+  - [x] Geo Fence and Range & Bearing schemas
   - [x] Route schemas (Route.xsd, tak-route.xsd)
   - [x] Marker schemas (2525, Icon Set, Spot)
 - [ ] Develop comprehensive tests for all new detail extensions

--- a/cotlib.go
+++ b/cotlib.go
@@ -1245,6 +1245,16 @@ func (e *Event) ValidateAt(now time.Time) error {
 				return fmt.Errorf("invalid uid: %w", err)
 			}
 		}
+		if e.Detail.Bullseye != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-bullseye", e.Detail.Bullseye.Raw); err != nil {
+				return fmt.Errorf("invalid bullseye: %w", err)
+			}
+		}
+		if e.Detail.RouteInfo != nil {
+			if err := validator.ValidateAgainstSchema("tak-details-routeinfo", e.Detail.RouteInfo.Raw); err != nil {
+				return fmt.Errorf("invalid routeinfo: %w", err)
+			}
+		}
 		if e.Detail.Environment != nil {
 			if err := validator.ValidateAgainstSchema("tak-details-environment", e.Detail.Environment.Raw); err != nil {
 				return fmt.Errorf("invalid environment: %w", err)

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -62,6 +62,18 @@ func TestValidateAgainstTAKDetailSchemas(t *testing.T) {
 			good:   []byte(`<attachment_list hashes="abc"/>`),
 			bad:    []byte(`<attachment_list/>`),
 		},
+		{
+			name:   "bullseye",
+			schema: "tak-details-bullseye",
+			good:   []byte(`<bullseye mils="true" distance="10" bearingRef="T" bullseyeUID="b" distanceUnits="u-r-b-bullseye" edgeToCenter="false" rangeRingVisible="true" title="t" hasRangeRings="false"/>`),
+			bad:    []byte(`<bullseye/>`),
+		},
+		{
+			name:   "routeinfo",
+			schema: "tak-details-routeinfo",
+			good:   []byte(`<__routeinfo><__navcues/></__routeinfo>`),
+			bad:    []byte(`<__routeinfo foo="bar"/>`),
+		},
 	}
 
 	for _, tt := range tests {

--- a/validator/schemas/details/bullseye.xsd
+++ b/validator/schemas/details/bullseye.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:simpleType name="bullseye_bearingRef">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="T"/>
+      <xs:enumeration value="M"/>
+      <xs:enumeration value="G"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="bullseyeType">
+    <xs:attribute name="mils" type="xs:boolean" use="required"/>
+    <xs:attribute name="distance" type="xs:decimal" use="required"/>
+    <xs:attribute name="bearingRef" type="bullseye_bearingRef" use="required"/>
+    <xs:attribute name="bullseyeUID" type="xs:string" use="required"/>
+    <xs:attribute name="distanceUnits" type="xs:string" fixed="u-r-b-bullseye" use="required"/>
+    <xs:attribute name="edgeToCenter" type="xs:boolean" use="required"/>
+    <xs:attribute name="rangeRingVisible" type="xs:boolean" use="required"/>
+    <xs:attribute name="title" type="xs:string" use="required"/>
+    <xs:attribute name="hasRangeRings" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:element name="bullseye" type="bullseyeType"/>
+</xs:schema>

--- a/validator/schemas/details/routeinfo.xsd
+++ b/validator/schemas/details/routeinfo.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:complexType name="routeinfoType">
+    <xs:sequence>
+      <xs:element name="__navcues" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="__routeinfo" type="routeinfoType"/>
+</xs:schema>

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -55,6 +55,12 @@ var takDetailsHeightXSD []byte
 //go:embed schemas/details/height_unit.xsd
 var takDetailsHeightUnitXSD []byte
 
+//go:embed schemas/details/bullseye.xsd
+var takDetailsBullseyeXSD []byte
+
+//go:embed schemas/details/routeinfo.xsd
+var takDetailsRouteInfoXSD []byte
+
 var (
 	schemas map[string]*Schema
 	once    sync.Once
@@ -213,6 +219,18 @@ func initSchemas() {
 		panic(fmt.Errorf("compile TAK details height_unit schema: %w", err))
 	}
 	schemas["tak-details-height_unit"] = takDetailsHeightUnit
+
+	takDetailsBullseye, err := Compile(takDetailsBullseyeXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile TAK details bullseye schema: %w", err))
+	}
+	schemas["tak-details-bullseye"] = takDetailsBullseye
+
+	takDetailsRouteInfo, err := Compile(takDetailsRouteInfoXSD)
+	if err != nil {
+		panic(fmt.Errorf("compile TAK details routeinfo schema: %w", err))
+	}
+	schemas["tak-details-routeinfo"] = takDetailsRouteInfo
 
 	eventPoint, err := Compile(eventPointXSD)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add bullseye and routeinfo detail schemas
- compile new schemas in validator
- validate bullseye and routeinfo in Event.ValidateAt
- test new schemas
- mark tasks complete

## Testing
- `go test ./...`