### PR TITLE
Expand benchmark coverage

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -10,7 +10,7 @@
   - [x] Route schemas (Route.xsd, tak-route.xsd)
   - [x] Marker schemas (2525, Icon Set, Spot)
 - [x] Develop comprehensive tests for all new detail extensions
-- [ ] Expand benchmarks for representative schemas
+- [x] Expand benchmarks for representative schemas
 
 ## Schema Integration Groups
 

--- a/validator/validator_bench_test.go
+++ b/validator/validator_bench_test.go
@@ -35,3 +35,43 @@ func BenchmarkValidateAgainstSchemaColor(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkValidateAgainstSchemaEnvironment(b *testing.B) {
+	xml := []byte(`<environment temperature="20" windDirection="10" windSpeed="5"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-environment", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkValidateAgainstSchemaPrecisionLocation(b *testing.B) {
+	xml := []byte(`<precisionlocation altsrc="GPS"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-precisionlocation", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkValidateAgainstSchemaShape(b *testing.B) {
+	xml := []byte(`<shape><polyline closed="true"><vertex lat="1" lon="1" hae="0"/></polyline></shape>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("tak-details-shape", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkValidateAgainstSchemaEventPoint(b *testing.B) {
+	xml := []byte(`<point lat="1" lon="2" hae="0" ce="0" le="0"/>`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := validator.ValidateAgainstSchema("event-point", xml); err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add validator benchmarks for environment, precisionlocation, shape, and event-point schemas
- mark benchmark task complete in TASKS.md

## Testing
- `go test ./...`
- `go test -bench . ./...`
