### PR TITLE
Add nil logger context test

### DIFF
--- a/cotlib_internal_test.go
+++ b/cotlib_internal_test.go
@@ -1,6 +1,7 @@
 package cotlib
 
 import (
+	"context"
 	"sync"
 	"testing"
 )
@@ -26,4 +27,18 @@ func TestMaxValueLenRace(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestLoggerFromContextWithNilLogger(t *testing.T) {
+	prev := logger.Load()
+	defer SetLogger(prev)
+
+	SetLogger(nil)
+
+	l := LoggerFromContext(context.Background())
+	if l == nil {
+		t.Fatal("LoggerFromContext returned nil")
+	}
+
+	l.Info("test message")
 }


### PR DESCRIPTION
## Summary
- test that `SetLogger(nil)` installs a default logger
- verify that `LoggerFromContext(context.Background())` is valid

## Testing
- `go test -v ./...`