### PR TITLE
fix validator initialization error handling

### DIFF
--- a/validator/compile_error_test.go
+++ b/validator/compile_error_test.go
@@ -1,0 +1,25 @@
+package validator_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/NERVsystems/cotlib/validator"
+)
+
+func TestValidateAgainstSchemaCompileError(t *testing.T) {
+	validator.ResetForTest()
+	orig := validator.EventPointXSD()
+	validator.SetEventPointXSDForTest(nil)
+	t.Cleanup(func() {
+		validator.SetEventPointXSDForTest(orig)
+		validator.ResetForTest()
+	})
+	err := validator.ValidateAgainstSchema("event-point", []byte(`<point lat="1" lon="1" hae="0" ce="0" le="0"/>`))
+	if err == nil || !strings.Contains(err.Error(), "compile event point schema") {
+		t.Fatalf("expected compile error, got %v", err)
+	}
+	if err2 := validator.ValidateAgainstSchema("event-point", nil); err2 == nil || err2.Error() != err.Error() {
+		t.Fatalf("expected same error on subsequent call, got %v", err2)
+	}
+}

--- a/validator/event.go
+++ b/validator/event.go
@@ -5,5 +5,8 @@ import _ "embed"
 //go:embed schemas/event/point.xsd
 var eventPointXSD []byte
 
+// defaultEventPointXSD holds the original event point schema bytes for testing.
+var defaultEventPointXSD = eventPointXSD
+
 // EventPointXSD returns the raw XSD bytes for the event point schema.
 func EventPointXSD() []byte { return eventPointXSD }

--- a/validator/test_helpers.go
+++ b/validator/test_helpers.go
@@ -12,6 +12,7 @@ func ResetForTest() {
 	initErr = nil
 	mkTemp = os.MkdirTemp
 	writeSchemasFn = writeSchemas
+	eventPointXSD = defaultEventPointXSD
 }
 
 // SetMkTempForTest sets the MkdirTemp function for testing.
@@ -22,4 +23,9 @@ func SetMkTempForTest(f func(string, string) (string, error)) {
 // SetWriteSchemasForTest sets the schema writing function for testing.
 func SetWriteSchemasForTest(f func(string) error) {
 	writeSchemasFn = f
+}
+
+// SetEventPointXSDForTest sets the event point schema bytes for testing.
+func SetEventPointXSDForTest(data []byte) {
+	eventPointXSD = data
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -138,103 +138,120 @@ func initSchemas() {
 
 	takDetailsEnvironment, err := Compile(takDetailsEnvironmentXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details environment schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details environment schema: %w", err)
+		return
 	}
 	schemas["tak-details-environment"] = takDetailsEnvironment
 
 	takDetailsFileshare, err := Compile(takDetailsFileshareXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details fileshare schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details fileshare schema: %w", err)
+		return
 	}
 	schemas["tak-details-fileshare"] = takDetailsFileshare
 
 	takDetailsPrecisionLocation, err := Compile(takDetailsPrecisionLocationXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details precisionlocation schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details precisionlocation schema: %w", err)
+		return
 	}
 	schemas["tak-details-precisionlocation"] = takDetailsPrecisionLocation
 
 	takDetailsTakv, err := Compile(takDetailsTakvXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details takv schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details takv schema: %w", err)
+		return
 	}
 	schemas["tak-details-takv"] = takDetailsTakv
 
 	takDetailsMission, err := Compile(takDetailsMissionXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details mission schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details mission schema: %w", err)
+		return
 	}
 	schemas["tak-details-mission"] = takDetailsMission
 
 	takDetailsShape, err := Compile(takDetailsShapeXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details shape schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details shape schema: %w", err)
+		return
 	}
 	schemas["tak-details-shape"] = takDetailsShape
 
 	takDetailsColor, err := Compile(takDetailsColorXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details color schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details color schema: %w", err)
+		return
 	}
 	schemas["tak-details-color"] = takDetailsColor
 
 	takDetailsHierarchy, err := Compile(takDetailsHierarchyXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details hierarchy schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details hierarchy schema: %w", err)
+		return
 	}
 	schemas["tak-details-hierarchy"] = takDetailsHierarchy
 
 	takDetailsGeofence, err := Compile(takDetailsGeofenceXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details __geofence schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details __geofence schema: %w", err)
+		return
 	}
 	schemas["tak-details-__geofence"] = takDetailsGeofence
 
 	takDetailsStrokeColor, err := Compile(takDetailsStrokeColorXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details strokecolor schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details strokecolor schema: %w", err)
+		return
 	}
 	schemas["tak-details-strokeColor"] = takDetailsStrokeColor
 
 	takDetailsStrokeWeight, err := Compile(takDetailsStrokeWeightXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details strokeweight schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details strokeweight schema: %w", err)
+		return
 	}
 	schemas["tak-details-strokeWeight"] = takDetailsStrokeWeight
 
 	takDetailsFillColor, err := Compile(takDetailsFillColorXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details fillcolor schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details fillcolor schema: %w", err)
+		return
 	}
 	schemas["tak-details-fillColor"] = takDetailsFillColor
 
 	takDetailsHeight, err := Compile(takDetailsHeightXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details height schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details height schema: %w", err)
+		return
 	}
 	schemas["tak-details-height"] = takDetailsHeight
 
 	takDetailsHeightUnit, err := Compile(takDetailsHeightUnitXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details height_unit schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details height_unit schema: %w", err)
+		return
 	}
 	schemas["tak-details-height_unit"] = takDetailsHeightUnit
 
 	takDetailsBullseye, err := Compile(takDetailsBullseyeXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details bullseye schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details bullseye schema: %w", err)
+		return
 	}
 	schemas["tak-details-bullseye"] = takDetailsBullseye
 
 	takDetailsRouteInfo, err := Compile(takDetailsRouteInfoXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile TAK details routeinfo schema: %w", err))
+		initErr = fmt.Errorf("compile TAK details routeinfo schema: %w", err)
+		return
 	}
 	schemas["tak-details-routeinfo"] = takDetailsRouteInfo
 
 	eventPoint, err := Compile(eventPointXSD)
 	if err != nil {
-		panic(fmt.Errorf("compile event point schema: %w", err))
+		initErr = fmt.Errorf("compile event point schema: %w", err)
+		return
 	}
 	schemas["event-point"] = eventPoint
 }


### PR DESCRIPTION
## Summary
- propagate schema compile errors instead of panicking
- allow tests to override the event point schema bytes
- add test covering compile failures

## Testing
- `go test -v ./...`
- `go test -bench . ./...`
