### PR TITLE
Add secure XML decoding for CoT type registration

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -248,16 +248,20 @@ func basicSyntaxOK(name string) bool {
 func RegisterCoTTypesFromFile(ctx context.Context, filename string) error {
 	logger := LoggerFromContext(ctx)
 
-	file, err := os.Open(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
-		logger.Error("failed to open file",
+		logger.Error("failed to read file",
 			"path", filename,
 			"error", err)
 		return err
 	}
-	defer file.Close()
 
-	// Simple structure to parse the XML
+	if doctypePattern.Match(data) {
+		logger.Error("invalid doctype detected",
+			"path", filename)
+		return ErrInvalidInput
+	}
+
 	var types struct {
 		XMLName xml.Name `xml:"types"`
 		CoTs    []struct {
@@ -265,8 +269,10 @@ func RegisterCoTTypesFromFile(ctx context.Context, filename string) error {
 		} `xml:"cot"`
 	}
 
-	decoder := xml.NewDecoder(file)
-	if err := decoder.Decode(&types); err != nil {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	dec.CharsetReader = nil
+	dec.Entity = nil
+	if err := decodeWithLimits(dec, &types); err != nil {
 		logger.Error("failed to decode XML",
 			"path", filename,
 			"error", err)
@@ -293,9 +299,18 @@ func RegisterCoTTypesFromFile(ctx context.Context, filename string) error {
 // RegisterCoTTypesFromReader loads and registers CoT types from an XML reader
 func RegisterCoTTypesFromReader(ctx context.Context, r io.Reader) error {
 	logger := LoggerFromContext(ctx)
-	decoder := xml.NewDecoder(r)
 
-	// Simple structure to parse the XML
+	data, err := io.ReadAll(r)
+	if err != nil {
+		logger.Error("failed to read from reader", "error", err)
+		return err
+	}
+
+	if doctypePattern.Match(data) {
+		logger.Error("invalid doctype detected")
+		return ErrInvalidInput
+	}
+
 	var types struct {
 		XMLName xml.Name `xml:"types"`
 		CoTs    []struct {
@@ -303,7 +318,10 @@ func RegisterCoTTypesFromReader(ctx context.Context, r io.Reader) error {
 		} `xml:"cot"`
 	}
 
-	if err := decoder.Decode(&types); err != nil {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	dec.CharsetReader = nil
+	dec.Entity = nil
+	if err := decodeWithLimits(dec, &types); err != nil {
 		logger.Error("failed to decode XML from reader",
 			"error", err)
 		return err
@@ -330,13 +348,13 @@ func RegisterCoTTypesFromReader(ctx context.Context, r io.Reader) error {
 func RegisterCoTTypesFromXMLContent(ctx context.Context, xmlContent string) error {
 	logger := LoggerFromContext(ctx)
 
-	// Use a Reader for the XML content
-	reader := strings.NewReader(xmlContent)
+	data := []byte(xmlContent)
 
-	// Use the standard decoder
-	decoder := xml.NewDecoder(reader)
+	if doctypePattern.Match(data) {
+		logger.Error("invalid doctype detected")
+		return ErrInvalidInput
+	}
 
-	// Simple structure to parse the XML
 	var types struct {
 		XMLName xml.Name `xml:"types"`
 		CoTs    []struct {
@@ -344,7 +362,10 @@ func RegisterCoTTypesFromXMLContent(ctx context.Context, xmlContent string) erro
 		} `xml:"cot"`
 	}
 
-	if err := decoder.Decode(&types); err != nil {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	dec.CharsetReader = nil
+	dec.Entity = nil
+	if err := decodeWithLimits(dec, &types); err != nil {
 		logger.Error("failed to decode XML content",
 			"error", err)
 		return err
@@ -375,7 +396,6 @@ func RegisterAllCoTTypes() error {
 func LoadCoTTypesFromFile(ctx context.Context, path string) error {
 	logger := LoggerFromContext(ctx)
 
-	// Read the file
 	data, err := os.ReadFile(path)
 	if err != nil {
 		logger.Error("failed to read file",
@@ -384,11 +404,19 @@ func LoadCoTTypesFromFile(ctx context.Context, path string) error {
 		return fmt.Errorf("failed to read file: %w", err)
 	}
 
-	// Parse the XML
+	if doctypePattern.Match(data) {
+		logger.Error("invalid doctype detected",
+			"path", path)
+		return ErrInvalidInput
+	}
+
 	var types struct {
 		Types []string `xml:"type"`
 	}
-	if err := xml.Unmarshal(data, &types); err != nil {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	dec.CharsetReader = nil
+	dec.Entity = nil
+	if err := decodeWithLimits(dec, &types); err != nil {
 		logger.Error("failed to parse XML",
 			"path", path,
 			"error", err)

--- a/cotlib_doctype_test.go
+++ b/cotlib_doctype_test.go
@@ -1,0 +1,63 @@
+package cotlib
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestTypeRegistrationsRejectDOCTYPE(t *testing.T) {
+	ctx := context.Background()
+	xmlData := "<?xml version=\"1.0\"?><!DOCTYPE foo><types><cot cot=\"a-f-G\"/></types>"
+
+	t.Run("RegisterCoTTypesFromXMLContent", func(t *testing.T) {
+		if err := RegisterCoTTypesFromXMLContent(ctx, xmlData); !errors.Is(err, ErrInvalidInput) {
+			t.Errorf("expected error, got %v", err)
+		}
+	})
+
+	t.Run("RegisterCoTTypesFromReader", func(t *testing.T) {
+		r := strings.NewReader(xmlData)
+		if err := RegisterCoTTypesFromReader(ctx, r); !errors.Is(err, ErrInvalidInput) {
+			t.Errorf("expected error, got %v", err)
+		}
+	})
+
+	t.Run("RegisterCoTTypesFromFile", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "types-*.xml")
+		if err != nil {
+			t.Fatalf("temp file: %v", err)
+		}
+		defer f.Close()
+		if _, err := f.WriteString(xmlData); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		if err := RegisterCoTTypesFromFile(ctx, f.Name()); !errors.Is(err, ErrInvalidInput) {
+			t.Errorf("expected error, got %v", err)
+		}
+	})
+
+	t.Run("LoadCoTTypesFromFile", func(t *testing.T) {
+		// structure for LoadCoTTypesFromFile
+		xmlData := "<?xml version=\"1.0\"?><!DOCTYPE foo><types><type>a-f-G</type></types>"
+		f, err := os.CreateTemp(t.TempDir(), "load-*.xml")
+		if err != nil {
+			t.Fatalf("temp file: %v", err)
+		}
+		defer f.Close()
+		if _, err := f.WriteString(xmlData); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		if err := LoadCoTTypesFromFile(ctx, f.Name()); !errors.Is(err, ErrInvalidInput) {
+			t.Errorf("expected error, got %v", err)
+		}
+	})
+}

--- a/cottypes/doctype_test.go
+++ b/cottypes/doctype_test.go
@@ -1,0 +1,15 @@
+package cottypes_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NERVsystems/cotlib/cottypes"
+)
+
+func TestRegisterXMLRejectsDOCTYPE(t *testing.T) {
+	data := []byte("<?xml version=\"1.0\"?><!DOCTYPE foo><types><cot cot=\"a-f-G\"/></types>")
+	if err := cottypes.RegisterXML(context.Background(), data); err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- secure RegisterCoTTypesFrom* functions by rejecting DOCTYPE and using `xml.NewDecoder` with protections
- enforce token limits when decoding CoT type lists
- harden `cottypes.RegisterXML` against hostile XML
- add tests verifying DOCTYPE is rejected for all registration helpers

## Testing
- `go test ./...`