### PR TITLE
docs: clarify TAKCoT schema coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,23 +52,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Type predicate checking
 - Event linking capabilities
 
-## [Unreleased]
+## [v0.3.2] - 2025-05-27
 
 ### Added
-- Detail extensions with round-trip preservation in `Detail.Unknown`
-- Validator package with schema checks for `__chat` extensions
+- Comprehensive TAKCoT schema validation, including complex schemas such as `Route.xsd`
+- Benchmarks and tests covering the expanded schema set
 
 ### Changed
-- Allowed `HAE` sentinel value `9999999.0` and expanded valid range to -12000..40000000
-
-### Deprecated
--
-
-### Removed
--
+- Secure XML decoding enforced across the library
+- Type catalog lookup now supports wildcard entries
 
 ### Fixed
--
-
-### Security
-- 
+- XML escape handling for newline and tab characters

--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ extensions. `validator.ValidateAgainstSchema` validates XML against embedded
 XSD files. `Event.Validate` automatically checks extensions such as
 `__chat`, `__chatReceipt`, `__group`, `__serverdestination`, `__video`,
 `attachment_list`, `usericon`, and the drawing-related details using these
-schemas.
+schemas. All schemas in this repository's `takcot/xsd` directory are embedded
+and validated, including those like `Route.xsd` that reference other files.
 
 ### Type Validation and Catalog
 

--- a/TAKCOT_SCHEMAS.md
+++ b/TAKCOT_SCHEMAS.md
@@ -62,10 +62,10 @@ The repository includes the complete set of TAKCoT schemas:
 
 ## Limitations
 
-Currently, only self-contained detail schemas are actively used in the validator. Complex schemas with dependencies (like the main Route.xsd) require additional work to resolve their includes and dependencies.
+All TAKCoT schemas from the upstream repository are embedded in the validator. This includes larger schemas such as `Route.xsd` that reference other files. These cross-file dependencies are resolved automatically during validation.
 
 ## Future Enhancements
 
-- Add support for complex schemas with dependencies
-- Include more TAKCoT schemas in the validator as needed
-- Add schema validation examples and test cases 
+- Provide additional schema validation examples and test cases.
+- Monitor the upstream ATAK repository for new TAKCoT schemas and
+  integrate them as they appear.


### PR DESCRIPTION
## Summary
- document that all schemas in `takcot/xsd` are bundled and validated
- note monitoring upstream ATAK for any new schema additions

## Testing
- `go test ./...`
