### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: Check formatting
+        run: |
+          gofmt -s -w $(git ls-files '*.go')
+          git diff --exit-code
+      - name: Run go vet
+        run: go vet ./...
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - name: Run gosec
+        run: gosec ./...
+      - name: Run tests
+        run: go test -v ./...


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run gofmt, go vet, gosec, and tests

## Testing
- `go vet ./...`
- `go install github.com/securego/gosec/v2/cmd/gosec@latest` *(fails: no route to host)*
- `gosec ./...` *(fails: command not found)*
- `go test -v ./...`