### PR TITLE
fix(ci): resolve gosec findings

### DIFF
--- a/cmd/cotgen/main.go
+++ b/cmd/cotgen/main.go
@@ -91,7 +91,13 @@ func main() {
 	for _, xmlFile := range xmlFiles {
 		logger.Debug("Processing XML file", "file", xmlFile)
 
-		data, err := os.ReadFile(xmlFile)
+		clean := filepath.Clean(xmlFile)
+		if strings.Contains(clean, "..") {
+			logger.Error("Invalid path", "file", xmlFile)
+			continue
+		}
+
+		data, err := os.ReadFile(clean)
 		if err != nil {
 			logger.Error("Failed to read XML file", "file", xmlFile, "error", err)
 			continue
@@ -217,7 +223,7 @@ func main() {
 		outputPath = "generated_types.go"
 	}
 
-	if err := os.WriteFile(outputPath, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(outputPath, buf.Bytes(), 0o600); err != nil {
 		logger.Error("Failed to write generated code", "output", outputPath, "error", err)
 		os.Exit(1)
 	}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -82,17 +82,17 @@ func writeSchemas(dir string) error {
 			if path == "." {
 				return nil
 			}
-			return os.MkdirAll(filepath.Join(dir, path), 0o755)
+			return os.MkdirAll(filepath.Join(dir, path), 0o750)
 		}
 		data, err := schemasFS.ReadFile(path)
 		if err != nil {
 			return err
 		}
 		dest := filepath.Join(dir, path)
-		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
 			return err
 		}
-		return os.WriteFile(dest, data, 0o644)
+		return os.WriteFile(dest, data, 0o600)
 	})
 }
 


### PR DESCRIPTION
## Summary
- handle error from catalog.Upsert
- sanitize filenames when reading CoT type files
- tighten permissions when writing schema files
- secure codegen output file

## Testing
- `go vet ./...`
- `gosec ./...` *(fails: command not found)*
- `go test -v ./...`