### PR TITLE
Add length checks in validator schema functions

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Install gosec
+go install github.com/securego/gosec/v2/cmd/gosec@latest

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -46,6 +46,7 @@ static void freeSchema(xmlSchemaPtr schema) {
 import "C"
 import (
 	"errors"
+	"math"
 	"runtime"
 	"unsafe"
 )
@@ -59,6 +60,9 @@ type Schema struct {
 func Compile(data []byte) (*Schema, error) {
 	if len(data) == 0 {
 		return nil, errors.New("empty schema")
+	}
+	if len(data) > math.MaxInt32 {
+		return nil, errors.New("schema too large")
 	}
 	ptr := C.compileSchema((*C.char)(unsafe.Pointer(&data[0])), C.int(len(data)))
 	if ptr == nil {
@@ -92,6 +96,9 @@ func (s *Schema) Validate(xml []byte) error {
 	}
 	if len(xml) == 0 {
 		return errors.New("empty xml")
+	}
+	if len(xml) > math.MaxInt32 {
+		return errors.New("xml too large")
 	}
 	ret := C.validateDoc(s.ptr, (*C.char)(unsafe.Pointer(&xml[0])), C.int(len(xml)))
 	if ret != 0 {


### PR DESCRIPTION
## Summary
- prevent overly large buffers from being passed to libxml
- add checks in Compile and Validate for MaxInt32
- add startup script for installing gosec

## Testing
- `go vet ./...`
- `gosec ./...` *(fails: command not found)*
- `go test -v ./...`