### PR TITLE
Remove stale time limit

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -1292,14 +1292,7 @@ func (e *Event) ValidateAt(now time.Time) error {
 	if staleDiff < minStaleOffset {
 		return fmt.Errorf("stale time too close to event time")
 	}
-	// Allow longer stale times for TAK types
-	maxStale := maxStaleOffset
-	if strings.HasPrefix(e.Type, "t-x-") {
-		maxStale = 30 * 24 * time.Hour // 30 days for TAK types
-	}
-	if staleDiff > maxStale {
-		return fmt.Errorf("stale time too far from event time")
-	}
+	// Skip maximum stale offset checks to allow extended validity
 
 	// Validate point
 	if err := e.Point.Validate(); err != nil {

--- a/cotlib_test.go
+++ b/cotlib_test.go
@@ -298,17 +298,15 @@ func TestEventValidation(t *testing.T) {
 
 	t.Run("stale_too_far_in_future", func(t *testing.T) {
 		event := *validEvent
-		// Use a non-TAK type to ensure stale time validation
 		event.Type = "a-f-G"
 		event.Stale = CoTTime(event.Time.Time().Add(8 * 24 * time.Hour))
-		if err := event.Validate(); err == nil {
-			t.Error("Event.Validate() error = nil, wantErr true for non-TAK type with stale > 7 days")
+		if err := event.Validate(); err != nil {
+			t.Errorf("Event.Validate() error = %v, wantErr false for long stale", err)
 		}
 
-		// TAK types are allowed to have longer stale times
 		event.Type = "t-x-takp-v"
 		if err := event.Validate(); err != nil {
-			t.Errorf("Event.Validate() error = %v, wantErr false for TAK type with long stale", err)
+			t.Errorf("Event.Validate() error = %v, wantErr false for long stale", err)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- skip max stale time checks in `Event.ValidateAt`
- adjust tests to allow long stale times for all events

## Testing
- `go test -v ./...`