### PR TITLE
fix(event schema init error handling)

### DIFF
--- a/event_schema.go
+++ b/event_schema.go
@@ -5,6 +5,7 @@ package cotlib
 import (
 	"encoding/xml"
 	"fmt"
+	"log/slog"
 
 	"github.com/NERVsystems/cotlib/validator"
 )
@@ -12,16 +13,23 @@ import (
 // eventPointSchema holds the compiled schema for CoT event points.
 var eventPointSchema *validator.Schema
 
+// initErr stores any error encountered during schema compilation.
+var initErr error
+
 func init() {
 	var err error
 	eventPointSchema, err = validator.Compile(validator.EventPointXSD())
 	if err != nil {
-		panic(fmt.Errorf("compile event point schema: %w", err))
+		initErr = fmt.Errorf("compile event point schema: %w", err)
+		slog.Error("failed to compile event point schema", "error", err)
 	}
 }
 
 // ValidateAgainstSchema validates the given CoT event XML against the point schema.
 func ValidateAgainstSchema(data []byte) error {
+	if initErr != nil {
+		return initErr
+	}
 	var p struct {
 		Point Point `xml:"point"`
 	}

--- a/event_schema_error_test.go
+++ b/event_schema_error_test.go
@@ -1,0 +1,31 @@
+package cotlib
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestValidateAgainstSchemaInitError ensures ValidateAgainstSchema returns the
+// initialization error instead of panicking when the schema failed to compile.
+func TestValidateAgainstSchemaInitError(t *testing.T) {
+	// Save original values
+	origSchema := eventPointSchema
+	origErr := initErr
+	defer func() {
+		eventPointSchema = origSchema
+		initErr = origErr
+	}()
+
+	// Simulate compilation failure
+	initErr = errors.New("compile fail")
+	eventPointSchema = nil
+
+	if err := ValidateAgainstSchema(nil); err == nil || err.Error() != initErr.Error() {
+		t.Fatalf("expected %v, got %v", initErr, err)
+	}
+
+	// Call again to ensure same error returned and no panic
+	if err := ValidateAgainstSchema(nil); err == nil || err.Error() != initErr.Error() {
+		t.Fatalf("expected %v on second call, got %v", initErr, err)
+	}
+}


### PR DESCRIPTION
## Summary
- log initialization failure of event schema
- return stored compile error from ValidateAgainstSchema
- add tests for init error behavior

## Testing
- `go test ./...`