### PR TITLE
Handle TAK chat with chatgrp

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ CoT events often include TAK-specific extensions inside the `<detail>` element.
 - `height_unit`
 - `remarks`
 
-All of these known TAK extensions are validated against embedded schemas when decoding and during event validation. Invalid XML will result in an error.
+All of these known TAK extensions are validated against embedded schemas when decoding and during event validation. Invalid XML will result in an error. Chat messages produced by TAK clients often include a `<chatgrp>` element inside `<__chat>`. `cotlib` first validates against the standard `chat` schema and automatically falls back to the TAK-specific `tak-details-__chat` schema so these messages are accepted.
 
 Example: adding a `shape` extension with a `strokeColor` attribute:
 

--- a/cotlib.go
+++ b/cotlib.go
@@ -1307,7 +1307,9 @@ func (e *Event) ValidateAt(now time.Time) error {
 				return fmt.Errorf("marshal chat: %w", err)
 			}
 			if err := validator.ValidateAgainstSchema("chat", data); err != nil {
-				return fmt.Errorf("chat validation failed: %w", err)
+				if err2 := validator.ValidateAgainstSchema("tak-details-__chat", data); err2 != nil {
+					return fmt.Errorf("chat validation failed: %w", err)
+				}
 			}
 		}
 		if e.Detail.ChatReceipt != nil {

--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -205,10 +205,28 @@ func (c *Chat) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 		return err
 	}
 	if err := validator.ValidateAgainstSchema("chat", raw); err != nil {
+		if err2 := validator.ValidateAgainstSchema("tak-details-__chat", raw); err2 != nil {
+			return err
+		}
+	}
+
+	var helper struct {
+		XMLName xml.Name `xml:"__chat"`
+		ID      string   `xml:"id,attr,omitempty"`
+		Message string   `xml:"message,attr,omitempty"`
+		Sender  string   `xml:"sender,attr,omitempty"`
+		_       string   `xml:",innerxml"`
+	}
+
+	if err := xml.Unmarshal(raw, &helper); err != nil {
 		return err
 	}
-	type alias Chat
-	return xml.Unmarshal(raw, (*alias)(c))
+
+	c.XMLName = helper.XMLName
+	c.ID = helper.ID
+	c.Message = helper.Message
+	c.Sender = helper.Sender
+	return nil
 }
 
 func (c *ChatReceipt) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {

--- a/validation_test.go
+++ b/validation_test.go
@@ -705,4 +705,22 @@ func TestTAKDetailSchemaValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("tak_chat_with_chatgrp", func(t *testing.T) {
+		now := time.Now().UTC()
+		xmlData := fmt.Sprintf(`<event version="2.0" uid="U" type="a-f-G" time="%[1]s" start="%[1]s" stale="%[2]s">`+
+			`<point lat="0" lon="0" hae="0" ce="1" le="1"/>`+
+			`<detail><__chat chatroom="c" groupOwner="false" id="1" senderCallsign="A"><chatgrp id="g" uid0="u0"/></__chat></detail>`+
+			`</event>`,
+			now.Format(cotlib.CotTimeFormat),
+			now.Add(10*time.Second).Format(cotlib.CotTimeFormat))
+		evt, err := cotlib.UnmarshalXMLEvent(context.Background(), []byte(xmlData))
+		if err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if err := evt.Validate(); err != nil {
+			t.Fatalf("validate: %v", err)
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
 }


### PR DESCRIPTION
## Summary
- handle `__chat` with `<chatgrp>` subelement
- fall back to TAK schema validation when needed
- validate chat in events with the same logic
- test TAK-style chat messages
- document schema fallback in README

## Testing
- `go test ./... > /tmp/go-test.log && tail -n 20 /tmp/go-test.log`