### PR TITLE
feat(validation): support dual chatreceipt schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ CoT events often include TAK-specific extensions inside the `<detail>` element.
 
 - `__chat`
 - `__chatReceipt`
+- `__chatreceipt`
 - `__geofence`
 - `__serverdestination`
 - `__video`


### PR DESCRIPTION
## Summary
- validate `ChatReceipt` against both `chatReceipt` and TAKCoT `__chatreceipt`
- preserve raw chat receipt XML and emit it during marshal
- handle `__chatreceipt` in Detail unmarshalling and Event validation
- add tests for both chat receipt schemas
- document additional chat receipt extension

## Testing
- `go test -v ./...`