### PR TITLE
feat(chat): preserve raw XML

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -1972,23 +1972,29 @@ func (e *Event) ToXML() ([]byte, error) {
 			buf.WriteString("/>\n")
 		}
 		if e.Detail.Chat != nil {
-			buf.WriteString("    <__chat")
-			if e.Detail.Chat.ID != "" {
-				buf.WriteString(` id="`)
-				buf.WriteString(escapeAttr(e.Detail.Chat.ID))
-				buf.WriteByte('"')
+			if len(e.Detail.Chat.Raw) > 0 {
+				buf.WriteString("    ")
+				buf.Write(e.Detail.Chat.Raw)
+				buf.WriteByte('\n')
+			} else {
+				buf.WriteString("    <__chat")
+				if e.Detail.Chat.ID != "" {
+					buf.WriteString(` id="`)
+					buf.WriteString(escapeAttr(e.Detail.Chat.ID))
+					buf.WriteByte('"')
+				}
+				if e.Detail.Chat.Message != "" {
+					buf.WriteString(` message="`)
+					buf.WriteString(escapeAttr(e.Detail.Chat.Message))
+					buf.WriteByte('"')
+				}
+				if e.Detail.Chat.Sender != "" {
+					buf.WriteString(` sender="`)
+					buf.WriteString(escapeAttr(e.Detail.Chat.Sender))
+					buf.WriteByte('"')
+				}
+				buf.WriteString("/>\n")
 			}
-			if e.Detail.Chat.Message != "" {
-				buf.WriteString(` message="`)
-				buf.WriteString(escapeAttr(e.Detail.Chat.Message))
-				buf.WriteByte('"')
-			}
-			if e.Detail.Chat.Sender != "" {
-				buf.WriteString(` sender="`)
-				buf.WriteString(escapeAttr(e.Detail.Chat.Sender))
-				buf.WriteByte('"')
-			}
-			buf.WriteString("/>\n")
 		}
 		if e.Detail.ChatReceipt != nil {
 			buf.WriteString("    <__chatReceipt")

--- a/validation_test.go
+++ b/validation_test.go
@@ -348,6 +348,9 @@ func TestDetailExtensionsRoundTrip(t *testing.T) {
 	if out.Detail == nil || out.Detail.Chat == nil || out.Detail.Chat.Message == "" {
 		t.Errorf("chat extension lost")
 	}
+	if want := []byte(`<__chat message="m" sender="s"></__chat>`); !bytes.Equal(out.Detail.Chat.Raw, want) {
+		t.Errorf("chat raw mismatch: got %s want %s", string(out.Detail.Chat.Raw), string(want))
+	}
 	if len(out.Detail.Unknown) != 1 {
 		t.Errorf("expected 1 unknown element, got %d", len(out.Detail.Unknown))
 	}


### PR DESCRIPTION
## Summary
- store the original `<__chat>` XML in a new `Chat.Raw` field
- retain the raw XML when decoding and emit it when serialising
- update tests for chat detail extension round trips

## Testing
- `go test ./...`
