### PR TITLE
fix chat Unmarshal retaining raw XML

### DIFF
--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -206,6 +206,7 @@ func (c *Chat) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	if err != nil {
 		return err
 	}
+	c.Raw = raw
 	if err := validator.ValidateAgainstSchema("chat", raw); err != nil {
 		if err2 := validator.ValidateAgainstSchema("tak-details-__chat", raw); err2 != nil {
 			return err


### PR DESCRIPTION
## Summary
- ensure `Chat` extension stores raw XML when decoding

## Testing
- `go test ./...`