### PR TITLE
docs: mention remarks schema and chat fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved event pool tests to be more resilient to parallel execution and race conditions
 - Added better test coverage for event pool reuse scenarios after XML parsing failures
 - Strengthened validation for chat extensions with dual schema support (simple chat and TAK chat)
+- Added `remarks` element schema derived from the MITRE CoT release, allowing validation via `tak-details-remarks`
+- Added regression test ensuring chat messages with `<chatgrp>` fall back to the TAK-specific schema
 
 ### Bug Fixes
 - Fixed race condition in event pool tests that caused failures when running with race detection

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ CoT events often include TAK-specific extensions inside the `<detail>` element.
 - `height_unit`
 - `remarks`
 
+The `remarks` extension now follows the MITRE *CoT Remarks Schema* and includes
+a `<remarks>` root element, enabling validation through the
+`tak-details-remarks` schema.
+
 All of these known TAK extensions are validated against embedded schemas when decoding and during event validation. Invalid XML will result in an error. Chat messages produced by TAK clients often include a `<chatgrp>` element inside `<__chat>`. `cotlib` first validates against the standard `chat` schema and automatically falls back to the TAK-specific `tak-details-__chat` schema so these messages are accepted.
 
 Example: adding a `shape` extension with a `strokeColor` attribute:


### PR DESCRIPTION
## Summary
- update README to mention remarks schema usage
- document remarks schema and chat fallback in CHANGELOG

## Testing
- `go test -v ./...`