### PR TITLE
Add expanded chat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ xmlData := `<?xml version="1.0"?>
 <event version="2.0" uid="EXT-1" type="t-x-c" time="2023-05-15T18:30:22Z" start="2023-05-15T18:30:22Z" stale="2023-05-15T18:30:32Z">
   <point lat="0" lon="0" ce="9999999.0" le="9999999.0"/>
   <detail>
-    <__chat message="Hello world!" sender="Alpha"/>
+    <__chat chatroom="room" groupOwner="false" id="1" senderCallsign="Alpha">
+      <chatgrp id="room" uid0="u0"/>
+    </__chat>
     <__video url="http://example/video"/>
   </detail>
 </event>`
@@ -204,6 +206,10 @@ evt, _ := cotlib.UnmarshalXMLEvent(context.Background(), []byte(xmlData))
 out, _ := evt.ToXML()
 fmt.Println(string(out)) // prints the same XML
 ```
+
+`Chat` now exposes additional fields such as `Chatroom`, `GroupOwner`,
+`SenderCallsign`, `Parent`, `MessageID` and a slice of `ChatGrp` entries
+representing group membership.
 
 ### Validator Package
 

--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -10,13 +10,29 @@ import (
 // RawMessage represents raw XML data preserved during decoding.
 type RawMessage []byte
 
-// Chat represents the TAK __chat extension with ID, Message, and Sender attributes.
+// ChatGrp represents a chat group entry within a chat message.
+type ChatGrp struct {
+	XMLName xml.Name `xml:"chatgrp"`
+	ID      string   `xml:"id,attr,omitempty"`
+	UID0    string   `xml:"uid0,attr,omitempty"`
+	UID1    string   `xml:"uid1,attr,omitempty"`
+	UID2    string   `xml:"uid2,attr,omitempty"`
+}
+
+// Chat represents the TAK __chat extension including group information.
 type Chat struct {
-	XMLName xml.Name   `xml:"__chat"`
-	ID      string     `xml:"id,attr,omitempty"`
-	Message string     `xml:"message,attr,omitempty"`
-	Sender  string     `xml:"sender,attr,omitempty"`
-	Raw     RawMessage `xml:"-"`
+	XMLName        xml.Name   `xml:"__chat"`
+	ID             string     `xml:"id,attr,omitempty"`
+	Message        string     `xml:"message,attr,omitempty"`
+	Sender         string     `xml:"sender,attr,omitempty"`
+	Chatroom       string     `xml:"chatroom,attr,omitempty"`
+	GroupOwner     string     `xml:"groupOwner,attr,omitempty"`
+	SenderCallsign string     `xml:"senderCallsign,attr,omitempty"`
+	Parent         string     `xml:"parent,attr,omitempty"`
+	MessageID      string     `xml:"messageId,attr,omitempty"`
+	ChatGrps       []ChatGrp  `xml:"chatgrp,omitempty"`
+	Hierarchy      *Hierarchy `xml:"hierarchy,omitempty"`
+	Raw            RawMessage `xml:"-"`
 }
 
 // ChatReceipt represents the TAK __chatReceipt extension acknowledging chat messages.
@@ -214,11 +230,18 @@ func (c *Chat) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	}
 
 	var helper struct {
-		XMLName xml.Name `xml:"__chat"`
-		ID      string   `xml:"id,attr,omitempty"`
-		Message string   `xml:"message,attr,omitempty"`
-		Sender  string   `xml:"sender,attr,omitempty"`
-		_       string   `xml:",innerxml"`
+		XMLName        xml.Name   `xml:"__chat"`
+		ID             string     `xml:"id,attr,omitempty"`
+		Message        string     `xml:"message,attr,omitempty"`
+		Sender         string     `xml:"sender,attr,omitempty"`
+		Chatroom       string     `xml:"chatroom,attr,omitempty"`
+		GroupOwner     string     `xml:"groupOwner,attr,omitempty"`
+		SenderCallsign string     `xml:"senderCallsign,attr,omitempty"`
+		Parent         string     `xml:"parent,attr,omitempty"`
+		MessageID      string     `xml:"messageId,attr,omitempty"`
+		ChatGrps       []ChatGrp  `xml:"chatgrp"`
+		Hierarchy      *Hierarchy `xml:"hierarchy"`
+		_              string     `xml:",innerxml"`
 	}
 
 	if err := xml.Unmarshal(raw, &helper); err != nil {
@@ -229,7 +252,23 @@ func (c *Chat) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	c.ID = helper.ID
 	c.Message = helper.Message
 	c.Sender = helper.Sender
+	c.Chatroom = helper.Chatroom
+	c.GroupOwner = helper.GroupOwner
+	c.SenderCallsign = helper.SenderCallsign
+	c.Parent = helper.Parent
+	c.MessageID = helper.MessageID
+	c.ChatGrps = helper.ChatGrps
+	c.Hierarchy = helper.Hierarchy
 	return nil
+}
+
+func (c Chat) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	if len(c.Raw) > 0 && c.Message == "" {
+		return encodeRaw(enc, c.Raw)
+	}
+	type alias Chat
+	start.Name.Local = "__chat"
+	return enc.EncodeElement(alias(c), start)
 }
 
 func (c *ChatReceipt) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {

--- a/validation_test.go
+++ b/validation_test.go
@@ -794,6 +794,22 @@ func TestTAKDetailSchemaValidation(t *testing.T) {
 		if err := evt.Validate(); err != nil {
 			t.Fatalf("validate: %v", err)
 		}
+		if evt.Detail == nil || evt.Detail.Chat == nil {
+			t.Fatalf("chat detail missing")
+		}
+		if evt.Detail.Chat.Chatroom != "c" {
+			t.Errorf("chatroom parsed incorrectly: %s", evt.Detail.Chat.Chatroom)
+		}
+		if len(evt.Detail.Chat.ChatGrps) != 1 || evt.Detail.Chat.ChatGrps[0].ID != "g" {
+			t.Errorf("chatgrp parsed incorrectly: %+v", evt.Detail.Chat.ChatGrps)
+		}
+		out, err := evt.ToXML()
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !bytes.Contains(out, []byte(`chatroom="c"`)) {
+			t.Errorf("expected chatroom attribute in output")
+		}
 		cotlib.ReleaseEvent(evt)
 	})
 


### PR DESCRIPTION
## Summary
- support TAK chat attributes and chat groups
- parse chat groups and hierarchy in chat XML
- ensure chat round-trip with chatgrp
- document extended chat fields

## Testing
- `go test ./... | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_683d81b6eb508324a99e4251a74fe085