### PR TITLE
feat(chat): support __chatreceipt fields

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -2007,18 +2007,80 @@ func (e *Event) ToXML() ([]byte, error) {
 			}
 		}
 		if e.Detail.ChatReceipt != nil {
-			if len(e.Detail.ChatReceipt.Raw) > 0 && e.Detail.ChatReceipt.Ack == "" {
+			cr := e.Detail.ChatReceipt
+			if len(cr.Raw) > 0 && cr.Ack == "" && cr.ID == "" && cr.Chatroom == "" && cr.GroupOwner == "" && cr.SenderCallsign == "" && cr.MessageID == "" && cr.Parent == "" && cr.ChatGrp == nil {
 				buf.WriteString("    ")
-				buf.Write(e.Detail.ChatReceipt.Raw)
+				buf.Write(cr.Raw)
 				buf.WriteByte('\n')
 			} else {
-				buf.WriteString("    <__chatReceipt")
-				if e.Detail.ChatReceipt.Ack != "" {
+				name := cr.XMLName.Local
+				if name == "" {
+					name = "__chatReceipt"
+				}
+				buf.WriteString("    <" + name)
+				if cr.Ack != "" {
 					buf.WriteString(` ack="`)
-					buf.WriteString(escapeAttr(e.Detail.ChatReceipt.Ack))
+					buf.WriteString(escapeAttr(cr.Ack))
 					buf.WriteByte('"')
 				}
-				buf.WriteString("/>\n")
+				if cr.ID != "" {
+					buf.WriteString(` id="`)
+					buf.WriteString(escapeAttr(cr.ID))
+					buf.WriteByte('"')
+				}
+				if cr.Chatroom != "" {
+					buf.WriteString(` chatroom="`)
+					buf.WriteString(escapeAttr(cr.Chatroom))
+					buf.WriteByte('"')
+				}
+				if cr.GroupOwner != "" {
+					buf.WriteString(` groupOwner="`)
+					buf.WriteString(escapeAttr(cr.GroupOwner))
+					buf.WriteByte('"')
+				}
+				if cr.SenderCallsign != "" {
+					buf.WriteString(` senderCallsign="`)
+					buf.WriteString(escapeAttr(cr.SenderCallsign))
+					buf.WriteByte('"')
+				}
+				if cr.MessageID != "" {
+					buf.WriteString(` messageId="`)
+					buf.WriteString(escapeAttr(cr.MessageID))
+					buf.WriteByte('"')
+				}
+				if cr.Parent != "" {
+					buf.WriteString(` parent="`)
+					buf.WriteString(escapeAttr(cr.Parent))
+					buf.WriteByte('"')
+				}
+				if cr.ChatGrp != nil {
+					buf.WriteString(">\n")
+					buf.WriteString("      <chatgrp")
+					if cr.ChatGrp.ID != "" {
+						buf.WriteString(` id="`)
+						buf.WriteString(escapeAttr(cr.ChatGrp.ID))
+						buf.WriteByte('"')
+					}
+					if cr.ChatGrp.UID0 != "" {
+						buf.WriteString(` uid0="`)
+						buf.WriteString(escapeAttr(cr.ChatGrp.UID0))
+						buf.WriteByte('"')
+					}
+					if cr.ChatGrp.UID1 != "" {
+						buf.WriteString(` uid1="`)
+						buf.WriteString(escapeAttr(cr.ChatGrp.UID1))
+						buf.WriteByte('"')
+					}
+					if cr.ChatGrp.UID2 != "" {
+						buf.WriteString(` uid2="`)
+						buf.WriteString(escapeAttr(cr.ChatGrp.UID2))
+						buf.WriteByte('"')
+					}
+					buf.WriteString("/>")
+					buf.WriteString("\n    </" + name + ">\n")
+				} else {
+					buf.WriteString("/>\n")
+				}
 			}
 		}
 		if e.Detail.Geofence != nil {

--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -3,6 +3,7 @@ package cotlib
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
 	"github.com/NERVsystems/cotlib/validator"
 	"io"
 )
@@ -19,11 +20,26 @@ type Chat struct {
 	Raw     RawMessage `xml:"-"`
 }
 
-// ChatReceipt represents the TAK __chatReceipt extension acknowledging chat messages.
+// ChatGrp represents the chatgrp element used in chat receipts.
+type ChatGrp struct {
+	ID   string `xml:"id,attr,omitempty"`
+	UID0 string `xml:"uid0,attr,omitempty"`
+	UID1 string `xml:"uid1,attr,omitempty"`
+	UID2 string `xml:"uid2,attr,omitempty"`
+}
+
+// ChatReceipt represents the TAK chat receipt extensions.
 type ChatReceipt struct {
-	XMLName xml.Name `xml:"__chatReceipt"`
-	Ack     string   `xml:"ack,attr"`
-	Raw     RawMessage
+	XMLName        xml.Name   `xml:""`
+	Ack            string     `xml:"ack,attr,omitempty"`
+	ID             string     `xml:"id,attr,omitempty"`
+	Chatroom       string     `xml:"chatroom,attr,omitempty"`
+	GroupOwner     string     `xml:"groupOwner,attr,omitempty"`
+	SenderCallsign string     `xml:"senderCallsign,attr,omitempty"`
+	MessageID      string     `xml:"messageId,attr,omitempty"`
+	Parent         string     `xml:"parent,attr,omitempty"`
+	ChatGrp        *ChatGrp   `xml:"chatgrp,omitempty"`
+	Raw            RawMessage `xml:"-"`
 }
 
 // Geofence represents the TAK __geofence extension.
@@ -238,20 +254,53 @@ func (c *ChatReceipt) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) err
 		return err
 	}
 	c.Raw = raw
-	if err := validator.ValidateAgainstSchema("chatReceipt", raw); err != nil {
+	switch start.Name.Local {
+	case "__chatReceipt":
+		if err := validator.ValidateAgainstSchema("chatReceipt", raw); err != nil {
+			return err
+		}
+		type alias ChatReceipt
+		return xml.Unmarshal(raw, (*alias)(c))
+	case "__chatreceipt":
 		if err := validator.ValidateAgainstSchema("tak-details-__chatreceipt", raw); err != nil {
 			return err
 		}
-		c.XMLName = start.Name
+		var helper struct {
+			XMLName        xml.Name `xml:"__chatreceipt"`
+			Ack            string   `xml:"ack,attr,omitempty"`
+			ID             string   `xml:"id,attr,omitempty"`
+			Chatroom       string   `xml:"chatroom,attr,omitempty"`
+			GroupOwner     string   `xml:"groupOwner,attr,omitempty"`
+			SenderCallsign string   `xml:"senderCallsign,attr,omitempty"`
+			MessageID      string   `xml:"messageId,attr,omitempty"`
+			Parent         string   `xml:"parent,attr,omitempty"`
+			ChatGrp        *ChatGrp `xml:"chatgrp,omitempty"`
+			_              string   `xml:",innerxml"`
+		}
+		if err := xml.Unmarshal(raw, &helper); err != nil {
+			return err
+		}
+		c.XMLName = helper.XMLName
+		c.Ack = helper.Ack
+		c.ID = helper.ID
+		c.Chatroom = helper.Chatroom
+		c.GroupOwner = helper.GroupOwner
+		c.SenderCallsign = helper.SenderCallsign
+		c.MessageID = helper.MessageID
+		c.Parent = helper.Parent
+		c.ChatGrp = helper.ChatGrp
 		return nil
+	default:
+		return fmt.Errorf("unknown element %s", start.Name.Local)
 	}
-	type alias ChatReceipt
-	return xml.Unmarshal(raw, (*alias)(c))
 }
 
 func (c ChatReceipt) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
-	if len(c.Raw) > 0 && c.Ack == "" {
+	if len(c.Raw) > 0 && c.Ack == "" && c.ID == "" && c.Chatroom == "" && c.GroupOwner == "" && c.SenderCallsign == "" && c.MessageID == "" && c.Parent == "" && c.ChatGrp == nil {
 		return encodeRaw(enc, c.Raw)
+	}
+	if c.XMLName.Local != "" {
+		start.Name = c.XMLName
 	}
 	type alias ChatReceipt
 	return enc.EncodeElement(alias(c), start)

--- a/validation_test.go
+++ b/validation_test.go
@@ -515,6 +515,18 @@ func TestChatReceiptTwoSchemas(t *testing.T) {
 	if len(r2.Raw) == 0 {
 		t.Error("expected raw preserved for detail chatreceipt")
 	}
+	if r2.ID != "1" || r2.Chatroom != "c" || r2.GroupOwner != "false" || r2.SenderCallsign != "A" {
+		t.Errorf("unexpected parsed chatreceipt: %+v", r2)
+	}
+	if r2.ChatGrp == nil || r2.ChatGrp.ID != "g" || r2.ChatGrp.UID0 != "u0" {
+		t.Errorf("unexpected chatgrp: %+v", r2.ChatGrp)
+	}
+	expectedRaw := `<__chatreceipt id="1" chatroom="c" groupOwner="false" senderCallsign="A"><chatgrp id="g" uid0="u0"></chatgrp></__chatreceipt>`
+	if b, err := xml.Marshal(&r2); err != nil {
+		t.Fatalf("marshal detail: %v", err)
+	} else if string(b) != expectedRaw {
+		t.Errorf("marshal mismatch: got %s want %s", string(b), expectedRaw)
+	}
 
 	now := time.Now().UTC()
 	evt1, _ := cotlib.NewEvent("CR1", "a-f-G", 0, 0, 1)


### PR DESCRIPTION
## Summary
- add ChatGrp struct and extend ChatReceipt with attributes
- support marshaling/unmarshaling new chat receipt fields
- encode chat receipts with nested chatgrp elements
- test parsing and emission of expanded chat receipt fields

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683d81b90a548324a22521d294d42533