### PR TITLE
Fix chat emission and struct duplication

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -2065,7 +2065,67 @@ func (e *Event) ToXML() ([]byte, error) {
 					buf.WriteString(escapeAttr(e.Detail.Chat.Sender))
 					buf.WriteByte('"')
 				}
-				buf.WriteString("/>\n")
+				if e.Detail.Chat.Chatroom != "" {
+					buf.WriteString(` chatroom="`)
+					buf.WriteString(escapeAttr(e.Detail.Chat.Chatroom))
+					buf.WriteByte('"')
+				}
+				if e.Detail.Chat.GroupOwner != "" {
+					buf.WriteString(` groupOwner="`)
+					buf.WriteString(escapeAttr(e.Detail.Chat.GroupOwner))
+					buf.WriteByte('"')
+				}
+				if e.Detail.Chat.SenderCallsign != "" {
+					buf.WriteString(` senderCallsign="`)
+					buf.WriteString(escapeAttr(e.Detail.Chat.SenderCallsign))
+					buf.WriteByte('"')
+				}
+				if e.Detail.Chat.Parent != "" {
+					buf.WriteString(` parent="`)
+					buf.WriteString(escapeAttr(e.Detail.Chat.Parent))
+					buf.WriteByte('"')
+				}
+				if e.Detail.Chat.MessageID != "" {
+					buf.WriteString(` messageId="`)
+					buf.WriteString(escapeAttr(e.Detail.Chat.MessageID))
+					buf.WriteByte('"')
+				}
+				if len(e.Detail.Chat.ChatGrps) == 0 && e.Detail.Chat.Hierarchy == nil {
+					buf.WriteString("/>\n")
+				} else {
+					buf.WriteString(">\n")
+					for _, g := range e.Detail.Chat.ChatGrps {
+						buf.WriteString("      <chatgrp")
+						if g.ID != "" {
+							buf.WriteString(` id="`)
+							buf.WriteString(escapeAttr(g.ID))
+							buf.WriteByte('"')
+						}
+						if g.UID0 != "" {
+							buf.WriteString(` uid0="`)
+							buf.WriteString(escapeAttr(g.UID0))
+							buf.WriteByte('"')
+						}
+						if g.UID1 != "" {
+							buf.WriteString(` uid1="`)
+							buf.WriteString(escapeAttr(g.UID1))
+							buf.WriteByte('"')
+						}
+						if g.UID2 != "" {
+							buf.WriteString(` uid2="`)
+							buf.WriteString(escapeAttr(g.UID2))
+							buf.WriteByte('"')
+						}
+						buf.WriteString("/>")
+						buf.WriteByte('\n')
+					}
+					if e.Detail.Chat.Hierarchy != nil {
+						buf.WriteString("      ")
+						buf.Write(e.Detail.Chat.Hierarchy.Raw)
+						buf.WriteByte('\n')
+					}
+					buf.WriteString("    </__chat>\n")
+				}
 			}
 		}
 		if e.Detail.ChatReceipt != nil {
@@ -2144,6 +2204,25 @@ func (e *Event) ToXML() ([]byte, error) {
 					buf.WriteString("/>\n")
 				}
 			}
+		}
+		if e.Detail.RouteInfo != nil {
+			buf.WriteString("    ")
+			buf.Write(e.Detail.RouteInfo.Raw)
+			buf.WriteByte('\n')
+		}
+		if e.Detail.Marti != nil {
+			buf.WriteString("    <marti>\n")
+			for _, d := range e.Detail.Marti.Dest {
+				buf.WriteString("      <dest")
+				if d.Callsign != "" {
+					buf.WriteString(` callsign="`)
+					buf.WriteString(escapeAttr(d.Callsign))
+					buf.WriteByte('"')
+				}
+				buf.WriteString("/>")
+				buf.WriteByte('\n')
+			}
+			buf.WriteString("    </marti>\n")
 		}
 		if e.Detail.Geofence != nil {
 			buf.WriteString("    ")

--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -36,14 +36,6 @@ type Chat struct {
 	Raw            RawMessage `xml:"-"`
 }
 
-// ChatGrp represents the chatgrp element used in chat receipts.
-type ChatGrp struct {
-	ID   string `xml:"id,attr,omitempty"`
-	UID0 string `xml:"uid0,attr,omitempty"`
-	UID1 string `xml:"uid1,attr,omitempty"`
-	UID2 string `xml:"uid2,attr,omitempty"`
-}
-
 // ChatReceipt represents the TAK chat receipt extensions.
 type ChatReceipt struct {
 	XMLName        xml.Name   `xml:""`

--- a/validation_test.go
+++ b/validation_test.go
@@ -838,6 +838,43 @@ func TestTAKDetailSchemaValidation(t *testing.T) {
 		if !bytes.Contains(out, []byte(`chatroom="c"`)) {
 			t.Errorf("expected chatroom attribute in output")
 		}
+		if !bytes.Contains(out, []byte(`groupOwner="false"`)) {
+			t.Errorf("expected groupOwner attribute in output")
+		}
+		if !bytes.Contains(out, []byte(`senderCallsign="A"`)) {
+			t.Errorf("expected senderCallsign attribute in output")
+		}
+		if !bytes.Contains(out, []byte(`<chatgrp`)) {
+			t.Errorf("expected chatgrp element in output")
+		}
+		cotlib.ReleaseEvent(evt)
+	})
+
+	t.Run("tak_chat_parent_messageid", func(t *testing.T) {
+		now := time.Now().UTC()
+		xmlData := fmt.Sprintf(`<event version="2.0" uid="U" type="a-f-G" time="%[1]s" start="%[1]s" stale="%[2]s">`+
+			`<point lat="0" lon="0" hae="0" ce="1" le="1"/>`+
+			`<detail><__chat chatroom="c" groupOwner="false" id="1" senderCallsign="A" parent="p" messageId="m"><chatgrp id="g" uid0="u0"/></__chat></detail>`+
+			`</event>`,
+			now.Format(cotlib.CotTimeFormat),
+			now.Add(10*time.Second).Format(cotlib.CotTimeFormat))
+		evt, err := cotlib.UnmarshalXMLEvent(context.Background(), []byte(xmlData))
+		if err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if evt.Detail.Chat.Parent != "p" || evt.Detail.Chat.MessageID != "m" {
+			t.Errorf("chat parent/messageId parsed incorrectly: %+v", evt.Detail.Chat)
+		}
+		out, err := evt.ToXML()
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !bytes.Contains(out, []byte(`parent="p"`)) {
+			t.Errorf("expected parent attribute in output")
+		}
+		if !bytes.Contains(out, []byte(`messageId="m"`)) {
+			t.Errorf("expected messageId attribute in output")
+		}
 		cotlib.ReleaseEvent(evt)
 	})
 


### PR DESCRIPTION
## Summary
- remove duplicate `ChatGrp` type
- serialize all chat attributes in `Event.ToXML`
- emit Marti detail in `Event.ToXML`
- expand chat roundtrip tests for all attributes
- add tests for parent and message ID fields

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683da6ebc4f88324b72c1898572d9929