### PR TITLE
Add chat validation and deleteChild

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -1348,6 +1348,10 @@ func (e *Event) ValidateAt(now time.Time) error {
 				if err2 := validator.ValidateAgainstSchema("tak-details-__chat", data); err2 != nil {
 					return fmt.Errorf("chat validation failed: %w", err)
 				}
+			} else {
+				if err := validator.ValidateChat(data); err != nil {
+					return fmt.Errorf("chat validation failed: %w", err)
+				}
 			}
 		}
 		if e.Detail.ChatReceipt != nil {
@@ -2088,6 +2092,11 @@ func (e *Event) ToXML() ([]byte, error) {
 				if e.Detail.Chat.MessageID != "" {
 					buf.WriteString(` messageId="`)
 					buf.WriteString(escapeAttr(e.Detail.Chat.MessageID))
+					buf.WriteByte('"')
+				}
+				if e.Detail.Chat.DeleteChild != "" {
+					buf.WriteString(` deleteChild="`)
+					buf.WriteString(escapeAttr(e.Detail.Chat.DeleteChild))
 					buf.WriteByte('"')
 				}
 				if len(e.Detail.Chat.ChatGrps) == 0 && e.Detail.Chat.Hierarchy == nil {

--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -31,6 +31,7 @@ type Chat struct {
 	SenderCallsign string     `xml:"senderCallsign,attr,omitempty"`
 	Parent         string     `xml:"parent,attr,omitempty"`
 	MessageID      string     `xml:"messageId,attr,omitempty"`
+	DeleteChild    string     `xml:"deleteChild,attr,omitempty"`
 	ChatGrps       []ChatGrp  `xml:"chatgrp,omitempty"`
 	Hierarchy      *Hierarchy `xml:"hierarchy,omitempty"`
 	Raw            RawMessage `xml:"-"`
@@ -282,6 +283,10 @@ func (c *Chat) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 		if err2 := validator.ValidateAgainstSchema("tak-details-__chat", raw); err2 != nil {
 			return err
 		}
+	} else {
+		if err := validator.ValidateChat(raw); err != nil {
+			return err
+		}
 	}
 
 	var helper struct {
@@ -294,6 +299,7 @@ func (c *Chat) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 		SenderCallsign string     `xml:"senderCallsign,attr,omitempty"`
 		Parent         string     `xml:"parent,attr,omitempty"`
 		MessageID      string     `xml:"messageId,attr,omitempty"`
+		DeleteChild    string     `xml:"deleteChild,attr,omitempty"`
 		ChatGrps       []ChatGrp  `xml:"chatgrp"`
 		Hierarchy      *Hierarchy `xml:"hierarchy"`
 		_              string     `xml:",innerxml"`
@@ -312,6 +318,7 @@ func (c *Chat) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	c.SenderCallsign = helper.SenderCallsign
 	c.Parent = helper.Parent
 	c.MessageID = helper.MessageID
+	c.DeleteChild = helper.DeleteChild
 	c.ChatGrps = helper.ChatGrps
 	c.Hierarchy = helper.Hierarchy
 	return nil


### PR DESCRIPTION
## Summary
- support `deleteChild` in `Chat` extension
- enforce `sender` and `message` using `validator.ValidateChat`
- test chat validation and deleteChild round trip

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683db889bb5c832498a43ae9fcda7a59