### PR TITLE
Remove obsolete nopool benchmark

### DIFF
--- a/cotlib_bench_test.go
+++ b/cotlib_bench_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
-	"fmt"
-	"io"
 	"testing"
 )
 
@@ -50,24 +48,6 @@ func BenchmarkUnmarshalXMLEvent(b *testing.B) {
 	}
 }
 
-func BenchmarkUnmarshalXMLEventNoPool(b *testing.B) {
-	evt, err := NewEvent("bench", "a-f-G", 30.0, -85.0, 0.0)
-	if err != nil {
-		b.Fatalf("NewEvent returned error: %v", err)
-	}
-	xmlData, err := evt.ToXML()
-	if err != nil {
-		b.Fatalf("ToXML error: %v", err)
-	}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if _, err := unmarshalXMLEventNoPool(xmlData); err != nil {
-			b.Fatalf("decode error: %v", err)
-		}
-	}
-}
-
 func BenchmarkValidateType(b *testing.B) {
 	types := []string{
 		"a-f-G",       // Valid basic type
@@ -99,27 +79,4 @@ func BenchmarkDecodeWithLimits(b *testing.B) {
 			b.Fatalf("decodeWithLimits error: %v", err)
 		}
 	}
-}
-
-func unmarshalXMLEventNoPool(data []byte) (*Event, error) {
-	if doctypePattern.Match(data) {
-		return nil, ErrInvalidInput
-	}
-	if idx := bytes.Index(data, []byte(`xmlns="`)); idx >= 0 {
-		end := bytes.Index(data[idx+7:], []byte(`"`))
-		if end > 1024 {
-			return nil, ErrInvalidInput
-		}
-	}
-	dec := xml.NewDecoder(io.LimitReader(bytes.NewReader(data), int64(len(data))))
-	dec.CharsetReader = nil
-	dec.Entity = nil
-	var evt Event
-	if err := decodeWithLimits(dec, &evt); err != nil {
-		return nil, fmt.Errorf("failed to decode XML: %w", err)
-	}
-	if err := evt.Validate(); err != nil {
-		return nil, err
-	}
-	return &evt, nil
 }


### PR DESCRIPTION
## Summary
- drop BenchmarkUnmarshalXMLEventNoPool and helper
- clean up unused imports

## Testing
- `go test -v ./...`
- `go test -bench . ./...` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_683dd0aee3388324ad20b377d8685f23