### PR TITLE
Add type metadata helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,21 @@ func main() {
     fmt.Printf("Description: %s\n", desc)
     // Output: Description: NBC EQUIPMENT
 
+    // Retrieve full type information
+    info, err := cotlib.GetTypeInfo("a-f-G-E-X-N")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("%s - %s\n", info.FullName, info.Description)
+    // Output: Gnd/Equip/Nbc Equipment - NBC EQUIPMENT
+
+    // Batch lookup for multiple types
+    infos, err := cotlib.GetTypeInfoBatch([]string{"a-f-G-E-X-N", "a-f-G-U-C"})
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("Batch size: %d\n", len(infos))
+
     // Search for types by description
     types := cotlib.FindTypesByDescription("NBC")
     for _, t := range types {

--- a/cotlib.go
+++ b/cotlib.go
@@ -1814,6 +1814,29 @@ func GetTypeDescription(name string) (string, error) {
 	return cottypes.GetCatalog().GetDescription(context.Background(), name)
 }
 
+// GetTypeInfo returns the metadata for a CoT type.
+// It includes the type code, full hierarchical name, and description.
+//
+// Returns an error if the type is not registered in the catalog.
+func GetTypeInfo(name string) (cottypes.Type, error) {
+	return cottypes.GetCatalog().GetType(context.Background(), name)
+}
+
+// GetTypeInfoBatch returns metadata for all provided type names.
+// If any lookup fails, the function returns an error.
+func GetTypeInfoBatch(names []string) ([]cottypes.Type, error) {
+	cat := cottypes.GetCatalog()
+	results := make([]cottypes.Type, 0, len(names))
+	for _, n := range names {
+		t, err := cat.GetType(context.Background(), n)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, t)
+	}
+	return results, nil
+}
+
 // FindTypesByDescription searches for types matching the given description.
 // The search is case-insensitive and matches partial descriptions.
 //

--- a/cotlib_test.go
+++ b/cotlib_test.go
@@ -1003,3 +1003,42 @@ func TestLookupTypeWildcardResolution(t *testing.T) {
 		t.Error("unexpected success for non-existent type")
 	}
 }
+
+func TestGetTypeInfo(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		info, err := GetTypeInfo("a-f-G-E-X-N")
+		if err != nil {
+			t.Fatalf("GetTypeInfo returned error: %v", err)
+		}
+		if info.Name != "a-f-G-E-X-N" {
+			t.Errorf("unexpected name: %s", info.Name)
+		}
+		if info.FullName == "" || info.Description == "" {
+			t.Error("missing metadata in Type")
+		}
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		if _, err := GetTypeInfo("bad-type"); err == nil {
+			t.Error("expected error for unknown type")
+		}
+	})
+}
+
+func TestGetTypeInfoBatch(t *testing.T) {
+	names := []string{"a-f-G-E-X-N", "a-f-G-U-C"}
+	infos, err := GetTypeInfoBatch(names)
+	if err != nil {
+		t.Fatalf("GetTypeInfoBatch returned error: %v", err)
+	}
+	if len(infos) != len(names) {
+		t.Fatalf("expected %d results, got %d", len(names), len(infos))
+	}
+	if infos[0].Name != names[0] || infos[1].Name != names[1] {
+		t.Error("batch results out of order or incorrect")
+	}
+
+	if _, err := GetTypeInfoBatch([]string{"a-f-G-E-X-N", "bad"}); err == nil {
+		t.Error("expected error when any lookup fails")
+	}
+}


### PR DESCRIPTION
## Summary
- add `GetTypeInfo` and `GetTypeInfoBatch` wrappers
- document new helpers in README
- test type info lookups

## Testing
- `go test -v ./...`

------
https://chatgpt.com/codex/tasks/task_e_683e9397de6083249673d38b814be0a1