### PR TITLE
feat(chat): add group chat detection

### DIFF
--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -38,6 +38,16 @@ type Chat struct {
 	Raw            RawMessage `xml:"-"`
 }
 
+// IsGroupChat reports whether the chat message targets a group.
+// A chat is considered a group chat when the Chatroom or GroupOwner
+// fields are non-empty or when any ChatGrp elements are present.
+func (c *Chat) IsGroupChat() bool {
+	if c == nil {
+		return false
+	}
+	return c.Chatroom != "" || c.GroupOwner != "" || len(c.ChatGrps) > 0
+}
+
 // ChatReceipt represents the TAK chat receipt extensions.
 type ChatReceipt struct {
 	XMLName        xml.Name   `xml:""`

--- a/examples_test.go
+++ b/examples_test.go
@@ -240,3 +240,14 @@ func Example_roundTripStrokeColorUsericon() {
 	// usericon: icon.png
 	// round-trip equal: true
 }
+
+func ExampleChat_IsGroupChat() {
+	direct := &cotlib.Chat{Message: "hi", Sender: "A"}
+	fmt.Println(direct.IsGroupChat())
+
+	group := &cotlib.Chat{Chatroom: "room", SenderCallsign: "A"}
+	fmt.Println(group.IsGroupChat())
+	// Output:
+	// false
+	// true
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -564,6 +564,37 @@ func TestChatReceiptTwoSchemas(t *testing.T) {
 	cotlib.ReleaseEvent(evt2)
 }
 
+func TestChatIsGroupChat(t *testing.T) {
+	cases := []struct {
+		name    string
+		xmlData string
+		want    bool
+	}{
+		{
+			name:    "direct",
+			xmlData: `<__chat sender="A" message="hi"/>`,
+			want:    false,
+		},
+		{
+			name:    "group",
+			xmlData: `<__chat chatroom="c" groupOwner="false" id="1" senderCallsign="A"><chatgrp id="c" uid0="u0"/></__chat>`,
+			want:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c cotlib.Chat
+			if err := xml.Unmarshal([]byte(tc.xmlData), &c); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := c.IsGroupChat(); got != tc.want {
+				t.Errorf("IsGroupChat()=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestTAKDetailSchemaValidation(t *testing.T) {
 	t.Run("contact", func(t *testing.T) {
 		evt, err := cotlib.NewEvent("C1", "t-x-d", 1, 1, 0)


### PR DESCRIPTION
## Summary
- add `Chat.IsGroupChat` helper to detect group messages
- show usage in examples
- test detection logic for group vs direct chat XML

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683e93a058fc8324aba1cf0820f31dd6