### PR TITLE
Add chat samples integration tests

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,66 @@
+package cotlib_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/NERVsystems/cotlib"
+)
+
+var (
+	timeRe  = regexp.MustCompile(`time="[^"]*"`)
+	startRe = regexp.MustCompile(`start="[^"]*"`)
+	staleRe = regexp.MustCompile(`stale="[^"]*"`)
+)
+
+func updateTimes(data []byte) []byte {
+	now := time.Now().UTC().Truncate(time.Second)
+	start := now.Add(-2 * time.Hour)
+	stale := now.Add(2 * time.Hour)
+	data = timeRe.ReplaceAll(data, []byte("time=\""+now.Format(cotlib.CotTimeFormat)+"\""))
+	data = startRe.ReplaceAll(data, []byte("start=\""+start.Format(cotlib.CotTimeFormat)+"\""))
+	data = staleRe.ReplaceAll(data, []byte("stale=\""+stale.Format(cotlib.CotTimeFormat)+"\""))
+	return data
+}
+
+func TestChatSamples(t *testing.T) {
+	entries, err := os.ReadDir("testdata/chat_samples")
+	if err != nil {
+		t.Fatalf("read samples: %v", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".xml" {
+			continue
+		}
+		t.Run(e.Name(), func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join("testdata/chat_samples", e.Name()))
+			if err != nil {
+				t.Fatalf("read file: %v", err)
+			}
+			raw = updateTimes(raw)
+			evt, err := cotlib.UnmarshalXMLEvent(context.Background(), raw)
+			if err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			defer cotlib.ReleaseEvent(evt)
+			if evt.Detail == nil {
+				t.Fatalf("missing detail")
+			}
+			found := false
+			for _, u := range evt.Detail.Unknown {
+				if bytes.Contains(u, []byte("_flow-tags_")) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Error("_flow-tags_ element not captured in Unknown")
+			}
+		})
+	}
+}

--- a/testdata/chat_samples/group_chat.xml
+++ b/testdata/chat_samples/group_chat.xml
@@ -1,0 +1,9 @@
+<event version="2.0" uid="CHAT-2" type="b-t-f" time="2020-01-01T00:00:00Z" start="2020-01-01T00:00:00Z" stale="2020-01-01T01:00:00Z">
+  <point lat="10" lon="20" hae="0" ce="1" le="1"/>
+  <detail>
+    <__chat chatroom="room" groupOwner="false" id="1" senderCallsign="Bravo">
+      <chatgrp id="room" uid0="Bravo"/>
+    </__chat>
+    <_flow-tags_ fbcb2="2020-01-01T00:00:00Z"/>
+  </detail>
+</event>

--- a/testdata/chat_samples/simple_chat.xml
+++ b/testdata/chat_samples/simple_chat.xml
@@ -1,0 +1,7 @@
+<event version="2.0" uid="CHAT-1" type="b-t-f" time="2020-01-01T00:00:00Z" start="2020-01-01T00:00:00Z" stale="2020-01-01T01:00:00Z">
+  <point lat="0" lon="0" hae="0" ce="1" le="1"/>
+  <detail>
+    <__chat sender="Alpha" message="Hello"/>
+    <_flow-tags_ adocs="2020-01-01T00:00:00Z"/>
+  </detail>
+</event>


### PR DESCRIPTION
## Summary
- add chat sample XML files
- update `integration_test.go` to parse each sample
- ensure `_flow-tags_` elements are captured during parsing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683fe1ee081883248823de8dca31f900