### PR TITLE
Make chat id optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ xmlData := `<?xml version="1.0"?>
 <event version="2.0" uid="EXT-1" type="t-x-c" time="2023-05-15T18:30:22Z" start="2023-05-15T18:30:22Z" stale="2023-05-15T18:30:32Z">
   <point lat="0" lon="0" ce="9999999.0" le="9999999.0"/>
   <detail>
-    <__chat chatroom="room" groupOwner="false" id="1" senderCallsign="Alpha">
+    <__chat chatroom="room" groupOwner="false" senderCallsign="Alpha">
       <chatgrp id="room" uid0="u0"/>
     </__chat>
     <__video url="http://example/video"/>
@@ -220,6 +220,8 @@ evt, _ := cotlib.UnmarshalXMLEvent(context.Background(), []byte(xmlData))
 out, _ := evt.ToXML()
 fmt.Println(string(out)) // prints the same XML
 ```
+
+The `id` attribute on `__chat` and `__chatreceipt` elements is optional.
 
 `Chat` now exposes additional fields such as `Chatroom`, `GroupOwner`,
 `SenderCallsign`, `Parent`, `MessageID` and a slice of `ChatGrp` entries

--- a/validator/schemas/details/__chat.xsd
+++ b/validator/schemas/details/__chat.xsd
@@ -10,7 +10,7 @@
             </xs:sequence>
             <xs:attribute name="chatroom" use="required"/>
             <xs:attribute name="groupOwner" use="required" type="xs:boolean"/>
-            <xs:attribute name="id" use="required"/>
+            <xs:attribute name="id" use="optional"/>
             <xs:attribute name="parent" type="xs:NCName"/>
             <xs:attribute name="senderCallsign" use="required" type="xs:NMTOKEN"/>
             <xs:attribute name="messageId"/> <!-- added messageId; not used by ATAK in some msgs -->

--- a/validator/schemas/details/__chatreceipt.xsd
+++ b/validator/schemas/details/__chatreceipt.xsd
@@ -8,7 +8,7 @@
             </xs:sequence>
             <xs:attribute name="chatroom" use="required"/>
             <xs:attribute name="groupOwner" use="required" type="xs:boolean"/>
-            <xs:attribute name="id" use="required"/>
+            <xs:attribute name="id" use="optional"/>
             <xs:attribute name="parent" type="xs:NCName"/>
             <xs:attribute name="senderCallsign" use="required" type="xs:NMTOKEN"/>
             <xs:attribute name="messageId"/>


### PR DESCRIPTION
## Summary
- update chat schemas so `id` is optional
- clarify optional `id` attribute in README
- allow chat messages and receipts without `id` in tests

## Testing
- `go test ./...` *(fails: undefined symbols)*

------
https://chatgpt.com/codex/tasks/task_e_6844358692688324a920297c87c2229d