### PR TITLE
Fix chat validation error handling

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -75,6 +75,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1441,7 +1442,7 @@ func (e *Event) ValidateAt(now time.Time) error {
 			}
 			if err := validator.ValidateAgainstSchema("chat", data); err != nil {
 				if err2 := validator.ValidateAgainstSchema("tak-details-__chat", data); err2 != nil {
-					return fmt.Errorf("chat validation failed: %w", err)
+					return fmt.Errorf("chat validation failed: %w", errors.Join(err, err2))
 				}
 			} else {
 				if err := validator.ValidateChat(data); err != nil {

--- a/detail_extensions.go
+++ b/detail_extensions.go
@@ -3,6 +3,7 @@ package cotlib
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 
@@ -292,7 +293,7 @@ func (c *Chat) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	c.Raw = raw
 	if err := validator.ValidateAgainstSchema("chat", raw); err != nil {
 		if err2 := validator.ValidateAgainstSchema("tak-details-__chat", raw); err2 != nil {
-			return err
+			return errors.Join(err, err2)
 		}
 	} else {
 		if err := validator.ValidateChat(raw); err != nil {


### PR DESCRIPTION
## Summary
- capture errors from fallback chat validation
- combine schema errors in event validation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684443c654c88324b9633e26f34de115