### PR TITLE
Add validation for Remarks tag case and test

### DIFF
--- a/cotlib.go
+++ b/cotlib.go
@@ -1011,6 +1011,9 @@ func (d *Detail) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 				}
 				d.Remarks = &r
 			default:
+				if strings.EqualFold(t.Name.Local, "remarks") {
+					return fmt.Errorf("unexpected element %s", t.Name.Local)
+				}
 				raw, err := captureRaw(dec, t)
 				if err != nil {
 					return err

--- a/validation_test.go
+++ b/validation_test.go
@@ -874,6 +874,18 @@ func TestTAKDetailSchemaValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("remarks_case_mismatch", func(t *testing.T) {
+		now := time.Now().UTC()
+		xmlData := fmt.Sprintf(`<event version="2.0" uid="U" type="a-f-G" time="%[1]s" start="%[1]s" stale="%[2]s">`+
+			`<point lat="0" lon="0" hae="0" ce="1" le="1"/>`+
+			`<detail><Remarks>hi</Remarks></detail></event>`,
+			now.Format(cotlib.CotTimeFormat),
+			now.Add(10*time.Second).Format(cotlib.CotTimeFormat))
+		if _, err := cotlib.UnmarshalXMLEvent(context.Background(), []byte(xmlData)); err == nil {
+			t.Fatal("expected error for unrecognized Remarks element")
+		}
+	})
+
 	t.Run("tak_chat_with_chatgrp", func(t *testing.T) {
 		now := time.Now().UTC()
 		xmlData := fmt.Sprintf(`<event version="2.0" uid="U" type="a-f-G" time="%[1]s" start="%[1]s" stale="%[2]s">`+


### PR DESCRIPTION
## Summary
- detect capitalized `<Remarks>` tags during unmarshalling
- add regression test expecting schema failure when `<Remarks>` is used instead of `<remarks>`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684443c476788324ad05e21d1fef4bd3