### PR TITLE
Update chat example with mandatory groupOwner

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ evt.Detail = &cotlib.Detail{
     Chat: &cotlib.Chat{
         ID:             "Room",
         Chatroom:       "Room",
+        GroupOwner:     "false",
         SenderCallsign: "Alpha",
         ChatGrps: []cotlib.ChatGrp{
             {ID: "Room", UID0: "AlphaUID", UID1: "BravoUID"},
@@ -263,6 +264,9 @@ evt.Detail = &cotlib.Detail{
 }
 out, _ := evt.ToXML()
 ```
+
+Note: the `groupOwner` attribute is mandatory for TAK chat messages. It must be
+present for schema validation to succeed when using the TAK chat format.
 
 Delivery or read receipts can be sent by populating `Detail.ChatReceipt` with
 the appropriate `Ack`, `ID`, and `MessageID` fields.


### PR DESCRIPTION
## Summary
- document groupOwner usage in chat message example
- note that the groupOwner attribute is required for TAK chat schema validation

## Testing
- `go test -v ./...`

------
https://chatgpt.com/codex/tasks/task_e_684447d048188324808fced839cf343f